### PR TITLE
Add Microsoft Edge Read Aloud TTS

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -165,6 +165,11 @@ If you want to implement a new command or query follow the established patterns.
     `-Djava.library.path`. No API key required.
   -
   `elite.intel.ai.mouth.google.GoogleTTSImpl` - cloud-based fallback via Google Cloud Text-to-Speech API. Requires a Google Cloud API key configured in the System settings tab.
+  - `elite.intel.ai.mouth.edge.EdgeTTSImpl` - unofficial cloud integration with the consumer Edge Read Aloud
+    service; it is not supported or endorsed by Microsoft. Select it
+    by entering the exact `edge://` sentinel as the TTS API key. It uses Java HTTP/WebSocket transport,
+    decodes the returned 24 kHz mono MP3 in process, and does not require an Azure subscription.
+    `dev.mccue:jlayer-decoder` is LGPL-licensed; see `THIRD_PARTY_NOTICES.md`.
 
 ### AI (LLM Integration)
 
@@ -196,7 +201,8 @@ The prompt size is capped at 8K tokens. Caching mechanisms are used where suppor
 
 ## Licensing
 
-If open-sourced, code falls under Creative Commons (e.g., CC BY-NC-SA 4.0). Attribute third-party work.
+The project is released under CC0 1.0 Universal; see `LICENSE`. Third-party components retain their own
+licenses and must be documented in `THIRD_PARTY_NOTICES.md` when distribution requires it.
 
 ## IDE Note: unused-declaration false positives
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ details, check out `DEVELOPERS.md` in the root. It covers the architecture (deco
 reflection) and principles like DRY and SRP. All PRs go through review.
 
 ## License
-The project is open-source under a [Creative Commons license CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en),
-so feel free to check out the code and contribute. (see [DEVELOPERS.md](DEVELOPERS.md) for details)
+The project is released under [CC0 1.0 Universal](LICENSE). Third-party components retain their own
+licenses; see [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+Feel free to check out the code and contribute. See [DEVELOPERS.md](DEVELOPERS.md) for details.
 
 ## Contact Developer / Join the Community
 If you run into issues, hit us up on GitHub issues or Feedback and bug reports are super welcome!

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -96,6 +96,11 @@ Two STT backends are supported behind a common interface:
 - **Google Cloud TTS** (cloud) - 14 voices across British, American, and Australian accents,
   selected at runtime via voice command.
 
+- **Microsoft Edge Read Aloud** (cloud) - an unofficial integration selected with the exact `edge://` TTS key
+  sentinel. It is not supported or endorsed by Microsoft. It uses native Java HTTP/WebSocket transport and an
+  in-process MP3 decoder; no Azure credentials or browser automation are involved. This is a private consumer
+  protocol and may require maintenance if Microsoft changes its endpoints, headers, token, or audio format.
+
 ---
 
 ## Game Data Pipeline

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,24 @@
+# Third-Party Notices
+
+EliteIntel is distributed under the repository's `LICENSE`. The following component retains its own license.
+
+## jlayer-decoder 2024.04.19
+
+- Maven coordinates: `dev.mccue:jlayer-decoder:2024.04.19`
+- Purpose: pure-Java decoding of Microsoft Edge Read Aloud's MPEG audio into PCM.
+- Provenance: a repackaged and modernized subset of JavaLayer from the
+  [java-audio-stack project](https://github.com/bowbahdoe/java-audio-stack/tree/v2024.04.19/jlayer-decoder).
+- Published module POM license metadata: GNU Lesser General Public License, version 2.1. The source tag's
+  top-level `LICENSE` contains LGPL-3.0; both texts are included because the upstream metadata is inconsistent.
+- Source: [java-audio-stack v2024.04.19](https://github.com/bowbahdoe/java-audio-stack/tree/v2024.04.19).
+
+The dependency is unmodified and is included in `elite_intel.jar` by the Gradle Shadow plugin. The complete
+LGPL texts are packaged under `META-INF/licenses/`. EliteIntel's source and Gradle build scripts provide the
+application code needed to rebuild the combined JAR with an interface-compatible version of the library.
+
+## MP3 decoder test fixture
+
+`EdgeMp3DecoderTest` contains a short excerpt of Espressif's 24 kHz mono MP3 test sample, “Furious Freak”
+by Kevin MacLeod. It is used only by the offline test suite and is attributed under
+[CC BY 3.0](https://creativecommons.org/licenses/by/3.0/) with its
+[original source](https://dl.espressif.com/dl/audio/ff-16b-1c-24000hz.mp3).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     // Text to Speech
     implementation 'com.google.cloud:google-cloud-texttospeech:2.73.0'
+    implementation 'dev.mccue:jlayer-decoder:2024.04.19'
 
     // Speech to Text
     implementation platform('com.google.cloud:libraries-bom:26.51.0')
@@ -133,6 +134,7 @@ sourceSets {
             include '**/*.xml'
             include '**/fonts/*.ttf'
             include 'META-INF/MANIFEST.MF'
+            include 'META-INF/licenses/*.txt'
             include '**/db-migration/*.sql'
             include '**/scripts/*.sh'
             include '**/scripts/*.bat'
@@ -165,6 +167,9 @@ shadowJar {
         attributes 'Main-Class': 'elite.intel.App'
     }
     mergeServiceFiles()
+    from("${rootProject.projectDir}/THIRD_PARTY_NOTICES.md") {
+        into 'META-INF'
+    }
     destinationDirectory = file("${rootProject.projectDir}/distribution")
     dependsOn extractLwjglNatives
 }

--- a/app/src/main/java/elite/intel/ai/ApiFactory.java
+++ b/app/src/main/java/elite/intel/ai/ApiFactory.java
@@ -13,6 +13,7 @@ import elite.intel.ai.brain.inference.xai.GrokAnalysisEndpoint;
 import elite.intel.ai.ears.EarsInterface;
 import elite.intel.ai.ears.parakeet.ParakeetSTTImpl;
 import elite.intel.ai.mouth.MouthInterface;
+import elite.intel.ai.mouth.edge.EdgeTTSImpl;
 import elite.intel.ai.mouth.google.GoogleTTSImpl;
 import elite.intel.ai.mouth.kokoro.KokoroTTS;
 import elite.intel.session.SystemSession;
@@ -64,17 +65,23 @@ public class ApiFactory {
     ///
     @SuppressWarnings({"SwitchStatementWithTooFewBranches", "EnhancedSwitchMigration"})
     public MouthInterface getMouthImpl() {
-        if (systemSession.useLocalTTS()) {
+        String apiKey = systemSession.getTtsApiKey();
+        ProviderEnum provider = KeyDetector.detectProvider(apiKey, "TTS");
+        return selectMouth(systemSession.useLocalTTS(), provider);
+    }
+
+    static MouthInterface selectMouth(boolean useLocalTts, ProviderEnum provider) {
+        if (useLocalTts) {
             KokoroTTS kokoro = KokoroTTS.getInstance();
             kokoro.setRole(KokoroTTS.Role.MAIN);
             return kokoro;
         }
 
-        String apiKey = SystemSession.getInstance().getTtsApiKey();
-        ProviderEnum provider = KeyDetector.detectProvider(apiKey, "TTS");
         switch (provider) {
             case GOOGLE_TTS:
                 return GoogleTTSImpl.getInstance();
+            case EDGE_TTS:
+                return EdgeTTSImpl.getInstance();
             // TODO: Add ElevenLabs, AWS Polly, etc.
             default:
                 KokoroTTS kokoro = KokoroTTS.getInstance();

--- a/app/src/main/java/elite/intel/ai/KeyDetector.java
+++ b/app/src/main/java/elite/intel/ai/KeyDetector.java
@@ -69,6 +69,9 @@ public class KeyDetector {
         if (key == null || key.isBlank()) {
             return ProviderEnum.UNKNOWN;
         }
+        if ("TTS".equals(category) && "edge://".equals(key)) {
+            return ProviderEnum.EDGE_TTS;
+        }
         List<ProviderEnum> matches = new ArrayList<>();
         for (Map.Entry<ProviderEnum, Pattern> entry : PATTERNS.entrySet()) {
             if (entry.getValue().matcher(key).matches() && entry.getKey().supportsCategory(category)) {

--- a/app/src/main/java/elite/intel/ai/ProviderEnum.java
+++ b/app/src/main/java/elite/intel/ai/ProviderEnum.java
@@ -13,6 +13,7 @@ public enum ProviderEnum {
     MISTRAL("LLM"),
     GOOGLE_STT("STT"),
     GOOGLE_TTS("TTS"),
+    EDGE_TTS("TTS"),
     GEMINI("LLM"),
     OPENAI("LLM"),
     ANTHROPIC("LLM"),

--- a/app/src/main/java/elite/intel/ai/brain/commons/AiResponseLanguagePolicy.java
+++ b/app/src/main/java/elite/intel/ai/brain/commons/AiResponseLanguagePolicy.java
@@ -15,7 +15,7 @@ public final class AiResponseLanguagePolicy {
      * Resolves the effective AI response language based on the system session configuration
      * and available Text-to-Speech (TTS) settings.
      * <p>
-     * Google TTS voices every language we ship, so it imposes nothing. The local Kokoro TTS constrains
+     * Google and Edge TTS voice every language we ship, so they impose nothing. The local Kokoro TTS constrains
      * only Cyrillic: its phonemizer cannot read the script at all, so RU/UK have to be answered in
      * English or they would not be spoken. Every other language is Latin-script and Kokoro speaks it,
      * using its nearest voice where it has no native one — German is voiced with an accent, which beats
@@ -28,7 +28,7 @@ public final class AiResponseLanguagePolicy {
     public static Language resolveEffectiveAiResponseLanguage(SystemSession systemSession) {
         Language sessionLanguage = systemSession.getLanguage();
 
-        if (isGoogleTtsConfiguredAndUsable(systemSession)) {
+        if (supportsConfiguredLanguage(systemSession)) {
             return sessionLanguage;
         }
 
@@ -40,5 +40,13 @@ public final class AiResponseLanguagePolicy {
             return false;
         }
         return KeyDetector.detectProvider(systemSession.getTtsApiKey(), "TTS") == ProviderEnum.GOOGLE_TTS;
+    }
+
+    private static boolean supportsConfiguredLanguage(SystemSession systemSession) {
+        if (systemSession.useLocalTTS()) {
+            return false;
+        }
+        ProviderEnum provider = KeyDetector.detectProvider(systemSession.getTtsApiKey(), "TTS");
+        return provider == ProviderEnum.GOOGLE_TTS || provider == ProviderEnum.EDGE_TTS;
     }
 }

--- a/app/src/main/java/elite/intel/ai/mouth/PACKAGE.md
+++ b/app/src/main/java/elite/intel/ai/mouth/PACKAGE.md
@@ -1,7 +1,7 @@
 # `elite.intel.ai.mouth` - Developer Reference
 
 The mouth package owns everything from a
-`VocalisationRequestEvent` to speaker output. It normalises the various vox event types produced by other packages, synthesises speech via one of two backends (offline Kokoro or Google Cloud), and publishes an authoritative playback lifecycle while STT remains active for barge-in.
+`VocalisationRequestEvent` to speaker output. It normalises the various vox event types produced by other packages, synthesises speech via offline Kokoro, Google Cloud, or the Edge consumer Read Aloud service, and publishes an authoritative playback lifecycle while STT remains active for barge-in.
 
 ---
 
@@ -41,6 +41,9 @@ AiVoxResponseEvent  NavigationVocalisationEvent  RadioTransmissionEvent  …
                                    Speaker
                           handle completion updates shared IsSpeakingEvent state
 ```
+
+`EdgeTTSImpl` is a third main-mouth branch with the same synthesis/playback queue shape as Google. Its transport
+returns MPEG, which is decoded and validated before the shared PCM sanitation, volume, and playback stages.
 
 ---
 
@@ -86,10 +89,9 @@ does not touch it.
 **`AiVoxResponseEvent` special handling**: If the event carries a
 `CompletableFuture`, `VocalisationRouter` passes it through to `VocalisationRequestEvent`; otherwise the request creates its own future. The eligible active Mouth claims the request's `VocalisationHandle` during the same EventBus dispatch. Guava queues reentrant posts, so the no-Mouth check runs through `GameEventBus.afterCurrentDispatch` only after the outer post has drained; checking immediately after a nested `publish` would reject the request before a Mouth sees it. Only the handle publishes `IsSpeakingEvent`, using a process-wide active-request count, so overlapping requests cannot report a false idle state. STT continues listening while the state is true and treats a commander transcript as barge-in.
 
-**`RadioTransmissionEvent` special handling**: The router uses `getRandomVoice()`
-on the active voice provider (Kokoro or Google), selecting any voice that is NOT the current session voice. Sets
-`isRadio=true` on the resulting
-`VocalisationRequestEvent`.
+**`RadioTransmissionEvent` special handling**: The router chooses a random Kokoro voice other than the current
+Kokoro session voice and sets `isRadio=true` on the resulting `VocalisationRequestEvent`. Cloud mouths ignore it;
+the Kokoro radio service owns this route.
 
 ---
 
@@ -109,7 +111,7 @@ An eligible running backend must call `event.handle().claimForPlayback()` before
 `ManagedService` provides `start()` and `stop()`. Implementations initialize their engine/workers and register
 on `GameEventBus` during `start()`, then unregister and settle owned handles during `stop()`.
 
-Current implementations: `KokoroTTS` (offline), `GoogleTTSImpl` (cloud).
+Current implementations: `KokoroTTS` (offline), `GoogleTTSImpl` (cloud), and `EdgeTTSImpl` (cloud).
 
 ---
 
@@ -268,6 +270,22 @@ Published after each sentence via
 
 ---
 
+## 5A. Edge Read Aloud Backend (`edge/`)
+
+`EdgeTTSImpl` follows the same two-queue and `VocalisationHandle` contract as the other mouths. The transport
+uses the consumer Read Aloud HTTP voice-list endpoint and WebSocket synthesis protocol. Escaped text is capped
+at 4096 UTF-8 bytes per request, MPEG frames are assembled before `EdgeMp3Decoder` converts them to 24 kHz,
+mono, signed PCM-16 little endian, and only that decoded PCM reaches `AudioDeClicker`.
+
+Application speech speed drives Edge's SSML prosody rate. SSML volume remains `+0%`; the application volume is
+applied exactly once to decoded PCM through `AudioDeClicker.applyVolume`. Edge is a main-mouth provider only;
+radio stays on the dedicated Kokoro route.
+
+The integration is unofficial and is not supported or endorsed by Microsoft. `dev.mccue:jlayer-decoder` is
+packaged under its own LGPL terms; see the repository's `THIRD_PARTY_NOTICES.md`.
+
+---
+
 ## 6. Audio Utilities
 
 ### `AudioDeClicker`
@@ -394,13 +412,16 @@ The `SPEAK` custom command blocks the command executor thread on the handle's `C
 | `google/GoogleTTSImpl` | Cloud backend; Google Cloud TTS API |
 | `google/GoogleVoices` | 11 Google voice enum with gender and Chirp3-HD character |
 | `google/GoogleVoiceProvider` | Voice selection + non-EN language override |
+| `edge/EdgeTTSImpl` | Edge Read Aloud queueing, decoded-PCM volume, playback, and request lifecycle |
+| `edge/EdgeReadAloudClient` | HTTP/WebSocket protocol, clock-skew retry, timeouts, and cancellation |
+| `edge/EdgeMp3Decoder` | MPEG to validated 24 kHz mono PCM-16 LE decoding |
 | `google/VoiceProvider<T>` | Interface for voice provider implementations |
 | `AudioDeClicker` | Fade-in + volume scaling on PCM-16 LE |
 | `RadioFilter` | Bandpass + static noise shortwave radio effect |
 | `subscribers/events/VocalisationRequestEvent` | Normalised TTS event (origin, voice, flags, handle) |
 | `subscribers/events/AiVoxResponseEvent` | LLM spoken answer; carries optional CompletableFuture |
 | `subscribers/events/TTSInterruptEvent` | Global or request-id-targeted interrupt signal |
-| `subscribers/events/VocalisationSuccessfulEvent` | Per-sentence completion event (Google only) |
+| `subscribers/events/VocalisationSuccessfulEvent` | Per-sentence completion event (Google and Edge) |
 
 ## Key Constants
 
@@ -409,6 +430,8 @@ The `SPEAK` custom command blocks the command executor thread on the handle's `C
 | `SAMPLE_RATE` | `24000` Hz | `KokoroTTS`, `GoogleTTSImpl`, `AudioDeClicker` |
 | Default Kokoro voice | `GEORGE` (sid=26) | `KokoroTTS` |
 | Default Google voice | `JENNIFER` | `GoogleVoiceProvider` |
+| Edge escaped-text limit | `4096` UTF-8 bytes | `EdgeSentenceSplitter` |
+| Default Edge voice | `en-US-EmmaMultilingualNeural` | `EdgeVoices` |
 | `NOISE_AMPLITUDE` | `50f` (~0.15% full scale) | `RadioFilter` |
 | `GAIN` | `1.4f` | `RadioFilter` |
 | HP cutoff | `300 Hz` | `RadioFilter` |

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioDecoder.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioDecoder.java
@@ -1,0 +1,8 @@
+package elite.intel.ai.mouth.edge;
+
+import java.io.IOException;
+
+/** Decodes Edge's compressed response to 24 kHz, signed PCM-16 mono little-endian audio. */
+interface EdgeAudioDecoder {
+    byte[] decode(byte[] compressedAudio) throws IOException;
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioOutput.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioOutput.java
@@ -1,0 +1,14 @@
+package elite.intel.ai.mouth.edge;
+
+import java.util.function.BooleanSupplier;
+
+/** Playback seam so queue and interruption behaviour can be tested without audio hardware. */
+interface EdgeAudioOutput {
+    void open() throws Exception;
+
+    boolean play(byte[] pcm, BooleanSupplier interrupted) throws Exception;
+
+    void interrupt();
+
+    void close();
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioStreamAssembler.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeAudioStreamAssembler.java
@@ -1,0 +1,43 @@
+package elite.intel.ai.mouth.edge;
+
+import java.io.ByteArrayOutputStream;
+
+/** Validates Edge WebSocket messages and assembles their MPEG audio payloads in arrival order. */
+final class EdgeAudioStreamAssembler {
+    private final ByteArrayOutputStream audio = new ByteArrayOutputStream();
+
+    /**
+     * @return {@code true} when the message ends the synthesis turn
+     */
+    boolean acceptText(String message) throws EdgeProtocolException {
+        EdgeProtocolMessageParser.Message parsed = EdgeProtocolMessageParser.parseText(message);
+        return switch (parsed.path()) {
+            case "response", "turn.start", "audio.metadata" -> false;
+            case "turn.end" -> true;
+            default -> throw new EdgeProtocolException(
+                    "Edge returned an unexpected text path: " + parsed.path());
+        };
+    }
+
+    void acceptBinary(byte[] frame) throws EdgeProtocolException {
+        EdgeProtocolMessageParser.Message parsed = EdgeProtocolMessageParser.parseBinary(frame);
+        if (!"audio".equals(parsed.path())) {
+            throw new EdgeProtocolException("Edge binary message path is not audio");
+        }
+        String contentType = parsed.headers().get("content-type");
+        if (contentType == null && parsed.body().length == 0) {
+            return;
+        }
+        if (!"audio/mpeg".equals(contentType)) {
+            throw new EdgeProtocolException("Edge binary message has an unexpected Content-Type");
+        }
+        if (parsed.body().length == 0) {
+            throw new EdgeProtocolException("Edge binary message contains no audio data");
+        }
+        audio.writeBytes(parsed.body());
+    }
+
+    byte[] audio() {
+        return audio.toByteArray();
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeMp3Decoder.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeMp3Decoder.java
@@ -1,0 +1,166 @@
+package elite.intel.ai.mouth.edge;
+
+import dev.mccue.jlayer.decoder.Bitstream;
+import dev.mccue.jlayer.decoder.Decoder;
+import dev.mccue.jlayer.decoder.Header;
+import dev.mccue.jlayer.decoder.JavaLayerException;
+import dev.mccue.jlayer.decoder.Obuffer;
+import dev.mccue.jlayer.decoder.SampleBuffer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/** Direct pure-Java MP3 decoding; it does not depend on optional Java Sound MP3 service providers. */
+final class EdgeMp3Decoder implements EdgeAudioDecoder {
+    private static final int[] MPEG_1_LAYER_3_BITRATES =
+            {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0};
+    private static final int[] MPEG_2_LAYER_3_BITRATES =
+            {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0};
+    private static final int[] MPEG_1_SAMPLE_RATES = {44_100, 48_000, 32_000};
+
+    @Override
+    public byte[] decode(byte[] compressedAudio) throws IOException {
+        if (compressedAudio == null || compressedAudio.length == 0) {
+            throw new IOException("Edge returned empty MP3 audio");
+        }
+        validateCompleteFrames(compressedAudio);
+        Bitstream bitstream = new Bitstream(new ByteArrayInputStream(compressedAudio));
+        Decoder decoder = new Decoder();
+        ByteArrayOutputStream pcm = new ByteArrayOutputStream(compressedAudio.length * 8);
+        IOException failure = null;
+        try {
+            Header header;
+            while ((header = bitstream.readFrame()) != null) {
+                try {
+                    Obuffer decoded = decoder.decodeFrame(header, bitstream);
+                    if (!(decoded instanceof SampleBuffer samples)) {
+                        throw new IOException("Edge MP3 decoder returned an unexpected sample buffer");
+                    }
+                    appendSamples(samples, pcm);
+                } finally {
+                    bitstream.closeFrame();
+                }
+            }
+        } catch (IOException e) {
+            failure = e;
+        } catch (JavaLayerException | RuntimeException e) {
+            failure = new IOException("Could not decode Edge MP3 audio", e);
+        } finally {
+            try {
+                bitstream.close();
+            } catch (JavaLayerException e) {
+                if (failure == null) {
+                    failure = new IOException("Could not close Edge MP3 decoder", e);
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        if (pcm.size() == 0) {
+            throw new IOException("Edge MP3 audio contained no decodable samples");
+        }
+        return pcm.toByteArray();
+    }
+
+    private static void appendSamples(SampleBuffer samples, ByteArrayOutputStream pcm) throws IOException {
+        if (samples.getSampleFrequency() != EdgeProtocolConstants.SAMPLE_RATE
+                || samples.getChannelCount() != 1) {
+            throw new IOException("Edge MP3 decoded to " + samples.getSampleFrequency() + " Hz, "
+                    + samples.getChannelCount() + " channels; expected 24000 Hz mono");
+        }
+        short[] buffer = samples.getBuffer();
+        for (int i = 0; i < samples.getBufferLength(); i++) {
+            short sample = buffer[i];
+            pcm.write(sample & 0xFF);
+            pcm.write((sample >>> 8) & 0xFF);
+        }
+    }
+
+    private static void validateCompleteFrames(byte[] mp3) throws IOException {
+        int offset = id3v2Length(mp3);
+        int frameCount = 0;
+        while (offset < mp3.length) {
+            if (mp3.length - offset == 128 && startsWith(mp3, offset, 'T', 'A', 'G')) {
+                offset += 128;
+                break;
+            }
+            if (mp3.length - offset < 4) {
+                throw new IOException("Edge MP3 ended inside an MPEG frame header");
+            }
+            int header = ((mp3[offset] & 0xFF) << 24)
+                    | ((mp3[offset + 1] & 0xFF) << 16)
+                    | ((mp3[offset + 2] & 0xFF) << 8)
+                    | (mp3[offset + 3] & 0xFF);
+            int frameLength = frameLength(header);
+            if (offset + frameLength > mp3.length) {
+                throw new IOException("Edge MP3 ended inside an MPEG audio frame");
+            }
+            offset += frameLength;
+            frameCount++;
+        }
+        if (offset != mp3.length || frameCount == 0) {
+            throw new IOException("Edge MP3 contains no complete MPEG audio frames");
+        }
+    }
+
+    private static int id3v2Length(byte[] mp3) throws IOException {
+        if (mp3.length < 3 || !startsWith(mp3, 0, 'I', 'D', '3')) {
+            return 0;
+        }
+        if (mp3.length < 10) {
+            throw new IOException("Edge MP3 contains a truncated ID3 header");
+        }
+        int size = 0;
+        for (int i = 6; i < 10; i++) {
+            if ((mp3[i] & 0x80) != 0) {
+                throw new IOException("Edge MP3 contains an invalid ID3 size");
+            }
+            size = (size << 7) | (mp3[i] & 0x7F);
+        }
+        int total = 10 + size + (((mp3[5] & 0x10) != 0) ? 10 : 0);
+        if (total > mp3.length) {
+            throw new IOException("Edge MP3 contains a truncated ID3 tag");
+        }
+        return total;
+    }
+
+    private static int frameLength(int header) throws IOException {
+        if ((header & 0xFFE0_0000) != 0xFFE0_0000) {
+            throw new IOException("Edge MP3 contains an invalid MPEG frame sync");
+        }
+        int version = (header >>> 19) & 0x3;
+        int layer = (header >>> 17) & 0x3;
+        int bitrateIndex = (header >>> 12) & 0xF;
+        int sampleRateIndex = (header >>> 10) & 0x3;
+        int channelMode = (header >>> 6) & 0x3;
+        if (version == 1 || layer != 1 || bitrateIndex == 0 || bitrateIndex == 15 || sampleRateIndex == 3) {
+            throw new IOException("Edge MP3 contains an unsupported MPEG frame header");
+        }
+        if (channelMode != 3) {
+            throw new IOException("Edge MP3 is not mono");
+        }
+        int sampleRate = MPEG_1_SAMPLE_RATES[sampleRateIndex];
+        if (version == 2) {
+            sampleRate /= 2;
+        } else if (version == 0) {
+            sampleRate /= 4;
+        }
+        if (sampleRate != EdgeProtocolConstants.SAMPLE_RATE) {
+            throw new IOException("Edge MP3 sample rate is " + sampleRate + " Hz; expected 24000 Hz");
+        }
+        int[] table = version == 3 ? MPEG_1_LAYER_3_BITRATES : MPEG_2_LAYER_3_BITRATES;
+        int bitrate = table[bitrateIndex] * 1_000;
+        int coefficient = version == 3 ? 144 : 72;
+        int padding = (header >>> 9) & 1;
+        return coefficient * bitrate / sampleRate + padding;
+    }
+
+    private static boolean startsWith(byte[] data, int offset, int first, int second, int third) {
+        return data.length - offset >= 3
+                && data[offset] == first && data[offset + 1] == second && data[offset + 2] == third;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolAuth.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolAuth.java
@@ -1,0 +1,88 @@
+package elite.intel.ai.mouth.edge;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/** Generates the MUID cookie and time-bound Sec-MS-GEC value used by Edge Read Aloud. */
+final class EdgeProtocolAuth {
+    private static final long WINDOWS_EPOCH_SECONDS = 11_644_473_600L;
+    private static final long FILETIME_TICKS_PER_SECOND = 10_000_000L;
+    private static final long TOKEN_WINDOW_SECONDS = 300L;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final Clock clock;
+    private final Supplier<byte[]> muidBytes;
+    private final AtomicLong clockSkewMillis = new AtomicLong();
+
+    EdgeProtocolAuth() {
+        this(Clock.systemUTC(), EdgeProtocolAuth::randomMuidBytes);
+    }
+
+    EdgeProtocolAuth(Clock clock, Supplier<byte[]> muidBytes) {
+        this.clock = clock;
+        this.muidBytes = muidBytes;
+    }
+
+    private String newMuid() {
+        byte[] bytes = muidBytes.get();
+        if (bytes == null || bytes.length != 16) {
+            throw new IllegalStateException("Edge MUID source must provide exactly 16 bytes");
+        }
+        return HexFormat.of().withUpperCase().formatHex(bytes);
+    }
+
+    String secMsGec() {
+        long unixSeconds = Instant.now(clock).plusMillis(clockSkewMillis.get()).getEpochSecond();
+        long roundedSeconds = unixSeconds - Math.floorMod(unixSeconds, TOKEN_WINDOW_SECONDS);
+        long filetimeTicks = Math.multiplyExact(
+                Math.addExact(roundedSeconds, WINDOWS_EPOCH_SECONDS), FILETIME_TICKS_PER_SECOND);
+        String input = filetimeTicks + EdgeProtocolConstants.TRUSTED_CLIENT_TOKEN;
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.US_ASCII));
+            return HexFormat.of().withUpperCase().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+    }
+
+    Map<String, String> withMuid(Map<String, String> headers) {
+        Map<String, String> combined = new LinkedHashMap<>(headers);
+        if (combined.containsKey("Cookie")) {
+            throw new IllegalArgumentException("Edge headers already contain a Cookie");
+        }
+        combined.put("Cookie", "muid=" + newMuid() + ";");
+        return combined;
+    }
+
+    void adjustToServerDate(String serverDate) throws EdgeProtocolException {
+        if (serverDate == null || serverDate.isBlank()) {
+            throw new EdgeProtocolException("Edge returned 403 without a server Date header");
+        }
+        try {
+            Instant server = ZonedDateTime.parse(serverDate, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
+            Instant adjustedClient = Instant.now(clock).plusMillis(clockSkewMillis.get());
+            clockSkewMillis.addAndGet(server.toEpochMilli() - adjustedClient.toEpochMilli());
+        } catch (DateTimeParseException e) {
+            throw new EdgeProtocolException("Edge returned an invalid server Date header", e);
+        }
+    }
+
+    private static byte[] randomMuidBytes() {
+        byte[] bytes = new byte[16];
+        SECURE_RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolConstants.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolConstants.java
@@ -1,0 +1,72 @@
+package elite.intel.ai.mouth.edge;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Constants mirrored from Microsoft Edge's consumer Read Aloud protocol and the upstream edge-tts client.
+ * They are not Azure Speech credentials. Microsoft can change this private protocol, so the token, Chromium
+ * version, endpoints, headers, or output format may require maintenance in a future release.
+ */
+final class EdgeProtocolConstants {
+    static final String TRUSTED_CLIENT_TOKEN = "6A5AA1D4EAFF4E9FB37E23D68491D6F4";
+    static final String CHROMIUM_FULL_VERSION = "143.0.3650.75";
+    static final String SEC_MS_GEC_VERSION = "1-" + CHROMIUM_FULL_VERSION;
+    static final String OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+    static final int SAMPLE_RATE = 24_000;
+
+    private static final String BASE_URL =
+            "speech.platform.bing.com/consumer/speech/synthesize/readaloud";
+    private static final String USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                    + "(KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36 Edg/143.0.0.0";
+
+    private EdgeProtocolConstants() {
+    }
+
+    static URI voiceListUri(EdgeProtocolAuth auth) {
+        return URI.create("https://" + BASE_URL + "/voices/list?trustedclienttoken="
+                + TRUSTED_CLIENT_TOKEN + "&Sec-MS-GEC=" + auth.secMsGec()
+                + "&Sec-MS-GEC-Version=" + SEC_MS_GEC_VERSION);
+    }
+
+    static URI synthesisUri(EdgeProtocolAuth auth, String connectionId) {
+        return URI.create("wss://" + BASE_URL + "/edge/v1?TrustedClientToken="
+                + TRUSTED_CLIENT_TOKEN + "&ConnectionId=" + connectionId
+                + "&Sec-MS-GEC=" + auth.secMsGec()
+                + "&Sec-MS-GEC-Version=" + SEC_MS_GEC_VERSION);
+    }
+
+    static Map<String, String> voiceHeaders(EdgeProtocolAuth auth) {
+        Map<String, String> headers = baseHeaders();
+        // WHY: Java HttpClient owns the HTTP authority pseudo-header; attempting to add Edge's "Authority"
+        // spelling as a normal header is rejected. The URI produces the same wire authority.
+        headers.put("Accept", "*/*");
+        headers.put("Sec-CH-UA", "\" Not;A Brand\";v=\"99\", \"Microsoft Edge\";v=\"143\", "
+                + "\"Chromium\";v=\"143\"");
+        headers.put("Sec-CH-UA-Mobile", "?0");
+        headers.put("Sec-Fetch-Site", "none");
+        headers.put("Sec-Fetch-Mode", "cors");
+        headers.put("Sec-Fetch-Dest", "empty");
+        return auth.withMuid(headers);
+    }
+
+    static Map<String, String> webSocketHeaders(EdgeProtocolAuth auth) {
+        Map<String, String> headers = baseHeaders();
+        headers.put("Pragma", "no-cache");
+        headers.put("Cache-Control", "no-cache");
+        headers.put("Origin", "chrome-extension://jdiccldimpdaibmpdkjnbmckianbfold");
+        // WHY: Java's WebSocket implementation writes and validates Sec-WebSocket-Version itself.
+        return auth.withMuid(headers);
+    }
+
+    private static Map<String, String> baseHeaders() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("User-Agent", USER_AGENT);
+        headers.put("Accept-Language", "en-US,en;q=0.9");
+        // WHY: upstream advertises gzip, Brotli, and Zstandard, but Java 21's BodyHandler does not decode those
+        // encodings. Omitting Accept-Encoding requests an identity voice-list body with identical JSON content.
+        return headers;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolException.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolException.java
@@ -1,0 +1,14 @@
+package elite.intel.ai.mouth.edge;
+
+import java.io.IOException;
+
+/** Signals a malformed or unexpected response from Edge's consumer Read Aloud service. */
+final class EdgeProtocolException extends IOException {
+    EdgeProtocolException(String message) {
+        super(message);
+    }
+
+    EdgeProtocolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolMessageParser.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeProtocolMessageParser.java
@@ -1,0 +1,82 @@
+package elite.intel.ai.mouth.edge;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Parses Edge's header-prefixed text messages and binary audio frames. */
+final class EdgeProtocolMessageParser {
+    record Message(Map<String, String> headers, byte[] body) {
+        String path() {
+            return headers.get("path");
+        }
+    }
+
+    private EdgeProtocolMessageParser() {
+    }
+
+    static Message parseText(String message) throws EdgeProtocolException {
+        if (message == null) {
+            throw new EdgeProtocolException("Edge returned a null text message");
+        }
+        byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+        int separator = indexOf(bytes, new byte[]{'\r', '\n', '\r', '\n'}, 0);
+        if (separator < 0) {
+            throw new EdgeProtocolException("Edge text message has no header separator");
+        }
+        Map<String, String> headers = parseHeaders(bytes, 0, separator);
+        return new Message(headers, Arrays.copyOfRange(bytes, separator + 4, bytes.length));
+    }
+
+    static Message parseBinary(byte[] frame) throws EdgeProtocolException {
+        if (frame == null || frame.length < 2) {
+            throw new EdgeProtocolException("Edge binary message is missing its header length");
+        }
+        int headerLength = Short.toUnsignedInt(ByteBuffer.wrap(frame, 0, 2).getShort());
+        int bodyStart = 2 + headerLength;
+        if (headerLength == 0 || bodyStart > frame.length) {
+            throw new EdgeProtocolException("Edge binary message has an invalid header length");
+        }
+        Map<String, String> headers = parseHeaders(frame, 2, bodyStart);
+        return new Message(headers, Arrays.copyOfRange(frame, bodyStart, frame.length));
+    }
+
+    private static Map<String, String> parseHeaders(byte[] bytes, int start, int end)
+            throws EdgeProtocolException {
+        String raw = new String(bytes, start, end - start, StandardCharsets.UTF_8);
+        Map<String, String> headers = new LinkedHashMap<>();
+        for (String line : raw.split("\\r\\n")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            int colon = line.indexOf(':');
+            if (colon <= 0) {
+                throw new EdgeProtocolException("Malformed Edge protocol header");
+            }
+            headers.put(line.substring(0, colon).toLowerCase(Locale.ROOT), line.substring(colon + 1));
+        }
+        if (!headers.containsKey("path")) {
+            throw new EdgeProtocolException("Edge protocol message is missing Path");
+        }
+        return Map.copyOf(headers);
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle, int start) {
+        for (int i = start; i <= haystack.length - needle.length; i++) {
+            boolean match = true;
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeReadAloudClient.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeReadAloudClient.java
@@ -1,0 +1,331 @@
+package elite.intel.ai.mouth.edge;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/** Native Java HTTP/WebSocket transport for Microsoft Edge's consumer Read Aloud protocol. */
+final class EdgeReadAloudClient implements EdgeSynthesisClient {
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration RECEIVE_TIMEOUT = Duration.ofSeconds(60);
+
+    private final HttpClient httpClient;
+    private final EdgeProtocolAuth auth;
+    private final Duration httpTimeout;
+    private final Duration connectTimeout;
+    private final Duration receiveTimeout;
+    private final ConcurrentMap<String, CompletableFuture<WebSocket>> connecting = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, WebSocket> active = new ConcurrentHashMap<>();
+    private final Set<String> inFlight = ConcurrentHashMap.newKeySet();
+    private final Set<String> cancelled = ConcurrentHashMap.newKeySet();
+
+    EdgeReadAloudClient() {
+        this(HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build(), new EdgeProtocolAuth(),
+                HTTP_TIMEOUT, CONNECT_TIMEOUT, RECEIVE_TIMEOUT);
+    }
+
+    EdgeReadAloudClient(HttpClient httpClient, EdgeProtocolAuth auth) {
+        this(httpClient, auth, HTTP_TIMEOUT, CONNECT_TIMEOUT, RECEIVE_TIMEOUT);
+    }
+
+    EdgeReadAloudClient(
+            HttpClient httpClient,
+            EdgeProtocolAuth auth,
+            Duration httpTimeout,
+            Duration connectTimeout,
+            Duration receiveTimeout
+    ) {
+        this.httpClient = httpClient;
+        this.auth = auth;
+        this.httpTimeout = httpTimeout;
+        this.connectTimeout = connectTimeout;
+        this.receiveTimeout = receiveTimeout;
+    }
+
+    @Override
+    public List<EdgeVoice> listVoices() throws IOException, InterruptedException {
+        HttpResponse<String> response = sendVoiceListRequest();
+        if (response.statusCode() == 403) {
+            adjustClock(response.headers());
+            response = sendVoiceListRequest();
+        }
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new EdgeProtocolException("Edge voice-list request failed with HTTP " + response.statusCode());
+        }
+        return EdgeVoiceListParser.parse(response.body());
+    }
+
+    @Override
+    public byte[] synthesize(EdgeSynthesisRequest request) throws IOException, InterruptedException {
+        inFlight.add(request.requestId());
+        try {
+            checkCancelled(request.requestId());
+            try {
+                return synthesizeOnce(request);
+            } catch (HandshakeFailure failure) {
+                if (failure.statusCode() != 403) {
+                    throw new EdgeProtocolException(
+                            "Edge WebSocket handshake failed with HTTP " + failure.statusCode(), failure);
+                }
+                checkCancelled(request.requestId());
+                adjustClock(failure.headers());
+                checkCancelled(request.requestId());
+                try {
+                    return synthesizeOnce(request);
+                } catch (HandshakeFailure retryFailure) {
+                    throw new EdgeProtocolException(
+                            "Edge WebSocket handshake failed after clock-skew retry with HTTP "
+                                    + retryFailure.statusCode(), retryFailure);
+                }
+            }
+        } finally {
+            inFlight.remove(request.requestId());
+            cancelled.remove(request.requestId());
+        }
+    }
+
+    @Override
+    public void cancel(String requestId) {
+        cancelled.add(requestId);
+        CompletableFuture<WebSocket> pending = connecting.remove(requestId);
+        if (pending != null) {
+            abortPending(pending);
+        }
+        WebSocket socket = active.remove(requestId);
+        if (socket != null) {
+            socket.abort();
+        }
+    }
+
+    @Override
+    public void cancelAll() {
+        new ArrayList<>(inFlight).forEach(this::cancel);
+        connecting.keySet().forEach(this::cancel);
+        active.keySet().forEach(this::cancel);
+    }
+
+    private HttpResponse<String> sendVoiceListRequest() throws IOException, InterruptedException {
+        HttpRequest.Builder request = HttpRequest.newBuilder(EdgeProtocolConstants.voiceListUri(auth))
+                .timeout(httpTimeout)
+                .GET();
+        EdgeProtocolConstants.voiceHeaders(auth).forEach(request::header);
+        return httpClient.send(request.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    }
+
+    private byte[] synthesizeOnce(EdgeSynthesisRequest request) throws IOException, InterruptedException,
+            HandshakeFailure {
+        checkCancelled(request.requestId());
+        String connectionId = EdgeSsml.requestId();
+        SynthesisListener listener = new SynthesisListener();
+        WebSocket.Builder builder = httpClient.newWebSocketBuilder().connectTimeout(connectTimeout);
+        EdgeProtocolConstants.webSocketHeaders(auth).forEach(builder::header);
+        CompletableFuture<WebSocket> pending = builder.buildAsync(
+                EdgeProtocolConstants.synthesisUri(auth, connectionId), listener);
+        connecting.put(request.requestId(), pending);
+        if (cancelled.contains(request.requestId())) {
+            cancel(request.requestId());
+            throw new EdgeProtocolException("Edge Read Aloud synthesis was cancelled");
+        }
+
+        WebSocket socket;
+        try {
+            socket = pending.get(connectTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            active.put(request.requestId(), socket);
+        } catch (ExecutionException e) {
+            throw handshakeOrProtocolFailure(e.getCause());
+        } catch (TimeoutException e) {
+            abortPending(pending);
+            throw new EdgeProtocolException("Timed out connecting to Edge Read Aloud", e);
+        } catch (CancellationException e) {
+            throw new EdgeProtocolException("Edge Read Aloud synthesis was cancelled", e);
+        } finally {
+            connecting.remove(request.requestId(), pending);
+        }
+
+        try {
+            checkCancelled(request.requestId());
+            String ssml = EdgeSsml.build(
+                    request.text(), request.voice().protocolName(), request.rate(), request.volume(), request.pitch());
+            send(socket, EdgeSsml.speechConfig(Instant.now()));
+            send(socket, EdgeSsml.ssmlMessage(ssml, Instant.now()));
+            byte[] audio = listener.result().get(receiveTimeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (audio.length == 0) {
+                throw new EdgeProtocolException("Edge Read Aloud returned no audio");
+            }
+            return audio;
+        } catch (ExecutionException e) {
+            Throwable cause = unwrap(e.getCause());
+            if (cause instanceof IOException io) {
+                throw io;
+            }
+            throw new EdgeProtocolException("Edge Read Aloud synthesis failed", cause);
+        } catch (TimeoutException e) {
+            throw new EdgeProtocolException("Timed out receiving Edge Read Aloud audio", e);
+        } catch (CancellationException e) {
+            throw new EdgeProtocolException("Edge Read Aloud synthesis was cancelled", e);
+        } finally {
+            active.remove(request.requestId(), socket);
+            socket.abort();
+        }
+    }
+
+    private static void send(WebSocket socket, String message) throws EdgeProtocolException {
+        try {
+            socket.sendText(message, true).join();
+        } catch (CompletionException e) {
+            throw new EdgeProtocolException("Could not send Edge Read Aloud protocol message", unwrap(e));
+        }
+    }
+
+    private void adjustClock(HttpHeaders headers) throws EdgeProtocolException {
+        auth.adjustToServerDate(headers.firstValue("Date").orElse(null));
+    }
+
+    private void checkCancelled(String requestId) throws EdgeProtocolException {
+        if (cancelled.contains(requestId)) {
+            throw new EdgeProtocolException("Edge Read Aloud synthesis was cancelled");
+        }
+    }
+
+    private static void abortPending(CompletableFuture<WebSocket> pending) {
+        pending.cancel(true);
+        try {
+            WebSocket completed = pending.getNow(null);
+            if (completed != null) {
+                completed.abort();
+            }
+        } catch (CancellationException | CompletionException ignored) {
+            // The failed/cancelled handshake has no socket to abort.
+        }
+    }
+
+    private static HandshakeFailure handshakeOrProtocolFailure(Throwable failure) throws EdgeProtocolException {
+        Throwable cause = unwrap(failure);
+        if (cause instanceof WebSocketHandshakeException handshake) {
+            return new HandshakeFailure(
+                    handshake.getResponse().statusCode(), handshake.getResponse().headers(), handshake);
+        }
+        throw new EdgeProtocolException("Could not connect to Edge Read Aloud", cause);
+    }
+
+    private static Throwable unwrap(Throwable failure) {
+        Throwable current = failure;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private static final class HandshakeFailure extends Exception {
+        private final int statusCode;
+        private final HttpHeaders headers;
+
+        private HandshakeFailure(int statusCode, HttpHeaders headers, Throwable cause) {
+            super(cause);
+            this.statusCode = statusCode;
+            this.headers = headers;
+        }
+
+        int statusCode() {
+            return statusCode;
+        }
+
+        HttpHeaders headers() {
+            return headers;
+        }
+    }
+
+    private static final class SynthesisListener implements WebSocket.Listener {
+        private final EdgeAudioStreamAssembler assembler = new EdgeAudioStreamAssembler();
+        private final java.io.ByteArrayOutputStream binaryFragments = new java.io.ByteArrayOutputStream();
+        private final StringBuilder textFragments = new StringBuilder();
+        private final CompletableFuture<byte[]> result = new CompletableFuture<>();
+
+        @Override
+        public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public CompletableFuture<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            textFragments.append(data);
+            if (last) {
+                handleText(webSocket, textFragments.toString());
+                textFragments.setLength(0);
+            }
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+            byte[] fragment = new byte[data.remaining()];
+            data.get(fragment);
+            binaryFragments.writeBytes(fragment);
+            if (last) {
+                handleBinary(binaryFragments.toByteArray());
+                binaryFragments.reset();
+            }
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            if (!result.isDone()) {
+                result.completeExceptionally(new EdgeProtocolException(
+                        "Edge Read Aloud closed before turn.end (status " + statusCode + ")"));
+            }
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            result.completeExceptionally(new EdgeProtocolException("Edge Read Aloud WebSocket error", error));
+        }
+
+        CompletableFuture<byte[]> result() {
+            return result;
+        }
+
+        private void handleText(WebSocket socket, String message) {
+            try {
+                if (assembler.acceptText(message)) {
+                    result.complete(assembler.audio());
+                    socket.sendClose(WebSocket.NORMAL_CLOSURE, "complete");
+                }
+            } catch (EdgeProtocolException e) {
+                result.completeExceptionally(e);
+            }
+        }
+
+        private void handleBinary(byte[] frame) {
+            try {
+                assembler.acceptBinary(frame);
+            } catch (EdgeProtocolException e) {
+                result.completeExceptionally(e);
+            }
+        }
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSentenceSplitter.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSentenceSplitter.java
@@ -1,0 +1,155 @@
+package elite.intel.ai.mouth.edge;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Punctuation-aware sentence splitting with an escaped UTF-8 limit for Edge's SSML messages. */
+final class EdgeSentenceSplitter {
+    static final int MAX_ESCAPED_TEXT_BYTES = 4_096;
+
+    private EdgeSentenceSplitter() {
+    }
+
+    static List<String> split(String text) {
+        if (text == null || text.isBlank()) {
+            return List.of();
+        }
+        List<String> sentences = sentenceBoundaries(text.strip());
+        List<String> bounded = new ArrayList<>();
+        for (String sentence : sentences) {
+            splitOversized(sentence, bounded);
+        }
+        return List.copyOf(bounded);
+    }
+
+    private static List<String> sentenceBoundaries(String text) {
+        List<String> result = new ArrayList<>();
+        int start = 0;
+        int index = 0;
+        while (index < text.length()) {
+            int codePoint = text.codePointAt(index);
+            int next = index + Character.charCount(codePoint);
+            if (codePoint == '\r' || codePoint == '\n') {
+                add(text, start, index, result);
+                start = skipWhitespace(text, next);
+                index = start;
+                continue;
+            }
+            if (!isTerminal(codePoint)) {
+                index = next;
+                continue;
+            }
+            int boundary = consumeSentenceEnd(text, next);
+            int following = skipWhitespace(text, boundary);
+            boolean asciiPeriodNeedsSpace = codePoint == '.' && following == boundary && boundary < text.length();
+            if (!asciiPeriodNeedsSpace) {
+                add(text, start, boundary, result);
+                start = following;
+                index = following;
+            } else {
+                index = next;
+            }
+        }
+        add(text, start, text.length(), result);
+        return result;
+    }
+
+    private static void splitOversized(String text, List<String> output) {
+        String remaining = text.strip();
+        while (escapedBytes(remaining) > MAX_ESCAPED_TEXT_BYTES) {
+            int split = largestFittingWhitespace(remaining);
+            if (split <= 0) {
+                split = largestFittingCodePoint(remaining);
+            }
+            add(remaining, 0, split, output);
+            remaining = remaining.substring(split).strip();
+        }
+        if (!remaining.isBlank()) {
+            output.add(remaining);
+        }
+    }
+
+    private static int largestFittingWhitespace(String text) {
+        int lastWhitespace = -1;
+        int index = 0;
+        while (index < text.length()) {
+            int codePoint = text.codePointAt(index);
+            int next = index + Character.charCount(codePoint);
+            if (Character.isWhitespace(codePoint) && escapedBytes(text.substring(0, index)) <= MAX_ESCAPED_TEXT_BYTES) {
+                lastWhitespace = index;
+            }
+            if (escapedBytes(text.substring(0, next)) > MAX_ESCAPED_TEXT_BYTES) {
+                break;
+            }
+            index = next;
+        }
+        return lastWhitespace;
+    }
+
+    private static int largestFittingCodePoint(String text) {
+        int index = 0;
+        int lastFit = 0;
+        while (index < text.length()) {
+            int next = index + Character.charCount(text.codePointAt(index));
+            if (escapedBytes(text.substring(0, next)) > MAX_ESCAPED_TEXT_BYTES) {
+                break;
+            }
+            lastFit = next;
+            index = next;
+        }
+        if (lastFit == 0) {
+            throw new IllegalArgumentException("A single character exceeds Edge's SSML text limit");
+        }
+        return lastFit;
+    }
+
+    private static int consumeSentenceEnd(String text, int index) {
+        int cursor = index;
+        while (cursor < text.length()) {
+            int codePoint = text.codePointAt(cursor);
+            if (!isTerminal(codePoint) && !isClosingPunctuation(codePoint)) {
+                break;
+            }
+            cursor += Character.charCount(codePoint);
+        }
+        return cursor;
+    }
+
+    private static int skipWhitespace(String text, int index) {
+        int cursor = index;
+        while (cursor < text.length()) {
+            int codePoint = text.codePointAt(cursor);
+            if (!Character.isWhitespace(codePoint)) {
+                break;
+            }
+            cursor += Character.charCount(codePoint);
+        }
+        return cursor;
+    }
+
+    private static boolean isTerminal(int codePoint) {
+        return codePoint == '.' || codePoint == '!' || codePoint == '?'
+                || codePoint == 0x2026 || codePoint == 0x3002
+                || codePoint == 0xFF01 || codePoint == 0xFF1F;
+    }
+
+    private static boolean isClosingPunctuation(int codePoint) {
+        return codePoint == '\"' || codePoint == '\'' || codePoint == 0x2019 || codePoint == 0x201D
+                || codePoint == 0x00BB || codePoint == ')' || codePoint == ']' || codePoint == 0xFF09;
+    }
+
+    private static int escapedBytes(String text) {
+        return EdgeSsml.escape(text).getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    private static void add(String text, int start, int end, List<String> result) {
+        if (end <= start) {
+            return;
+        }
+        String sentence = text.substring(start, end).strip();
+        if (!sentence.isBlank()) {
+            result.add(sentence);
+        }
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSsml.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSsml.java
@@ -1,0 +1,110 @@
+package elite.intel.ai.mouth.edge;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.UUID;
+
+/** Builds escaped SSML and the text messages used by the Edge Read Aloud WebSocket. */
+final class EdgeSsml {
+    private static final DateTimeFormatter EDGE_TIMESTAMP = DateTimeFormatter.ofPattern(
+            "EEE MMM dd yyyy HH:mm:ss 'GMT+0000 (Coordinated Universal Time)'", Locale.US)
+            .withZone(ZoneOffset.UTC);
+
+    private EdgeSsml() {
+    }
+
+    static String build(String text, String voiceName, String rate, String volume, String pitch) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Edge SSML text must not be blank");
+        }
+        return "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>"
+                + "<voice name='" + escape(voiceName) + "'>"
+                + "<prosody pitch='" + pitch + "' rate='" + rate + "' volume='" + volume + "'>"
+                + escape(text) + "</prosody></voice></speak>";
+    }
+
+    static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder(value.length());
+        value.codePoints().forEach(codePoint -> {
+            if (isUnsupportedControl(codePoint)) {
+                escaped.append(' ');
+                return;
+            }
+            switch (codePoint) {
+                case '&' -> escaped.append("&amp;");
+                case '<' -> escaped.append("&lt;");
+                case '>' -> escaped.append("&gt;");
+                case '\"' -> escaped.append("&quot;");
+                case '\'' -> escaped.append("&apos;");
+                default -> escaped.appendCodePoint(codePoint);
+            }
+        });
+        return escaped.toString();
+    }
+
+    static String rate(float applicationSpeed) {
+        int percent = Math.round(applicationSpeed * 100f);
+        return signed(percent, "%");
+    }
+
+    static String volume(int applicationVolume) {
+        int bounded = Math.max(0, Math.min(100, applicationVolume));
+        return signed(bounded - 100, "%");
+    }
+
+    static String pitch(int hertz) {
+        return signed(hertz, "Hz");
+    }
+
+    static String protocolVoiceName(String shortName) {
+        if (shortName == null || !shortName.endsWith("Neural")) {
+            throw new IllegalArgumentException("Invalid Edge voice short name: " + shortName);
+        }
+        int voiceSeparator = shortName.lastIndexOf('-');
+        if (voiceSeparator <= 0 || voiceSeparator == shortName.length() - 1) {
+            throw new IllegalArgumentException("Invalid Edge voice short name: " + shortName);
+        }
+        String locale = shortName.substring(0, voiceSeparator);
+        String name = shortName.substring(voiceSeparator + 1);
+        return "Microsoft Server Speech Text to Speech Voice (" + locale + ", " + name + ")";
+    }
+
+    static String speechConfig(Instant now) {
+        return "X-Timestamp:" + timestamp(now) + "\r\n"
+                + "Content-Type:application/json; charset=utf-8\r\n"
+                + "Path:speech.config\r\n\r\n"
+                + "{\"context\":{\"synthesis\":{\"audio\":{\"metadataoptions\":{"
+                + "\"sentenceBoundaryEnabled\":\"true\",\"wordBoundaryEnabled\":\"false\"},"
+                + "\"outputFormat\":\"" + EdgeProtocolConstants.OUTPUT_FORMAT + "\"}}}}\r\n";
+    }
+
+    static String ssmlMessage(String ssml, Instant now) {
+        return "X-RequestId:" + requestId() + "\r\n"
+                + "Content-Type:application/ssml+xml\r\n"
+                // WHY: the extra Z after Edge's JavaScript-style UTC timestamp is a required service quirk.
+                + "X-Timestamp:" + timestamp(now) + "Z\r\n"
+                + "Path:ssml\r\n\r\n" + ssml;
+    }
+
+    static String requestId() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static String timestamp(Instant instant) {
+        return EDGE_TIMESTAMP.format(instant);
+    }
+
+    private static String signed(int value, String suffix) {
+        return (value >= 0 ? "+" : "") + value + suffix;
+    }
+
+    private static boolean isUnsupportedControl(int codePoint) {
+        return codePoint <= 8 || (codePoint >= 11 && codePoint <= 12)
+                || (codePoint >= 14 && codePoint <= 31);
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSynthesisClient.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSynthesisClient.java
@@ -1,0 +1,17 @@
+package elite.intel.ai.mouth.edge;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Transport seam for deterministic tests and the native Java Edge Read Aloud client. */
+interface EdgeSynthesisClient {
+    List<EdgeVoice> listVoices() throws IOException, InterruptedException;
+
+    byte[] synthesize(EdgeSynthesisRequest request) throws IOException, InterruptedException;
+
+    default void cancel(String requestId) {
+    }
+
+    default void cancelAll() {
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSynthesisRequest.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeSynthesisRequest.java
@@ -1,0 +1,23 @@
+package elite.intel.ai.mouth.edge;
+
+/** Provider-specific synthesis request after voice and prosody resolution. */
+record EdgeSynthesisRequest(
+        String requestId,
+        String text,
+        EdgeVoice voice,
+        String rate,
+        String volume,
+        String pitch
+) {
+    EdgeSynthesisRequest {
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalArgumentException("Edge synthesis request id must not be blank");
+        }
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("Edge synthesis text must not be blank");
+        }
+        if (voice == null) {
+            throw new IllegalArgumentException("Edge synthesis voice must not be null");
+        }
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeTTSImpl.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeTTSImpl.java
@@ -1,0 +1,554 @@
+package elite.intel.ai.mouth.edge;
+
+import com.google.common.eventbus.Subscribe;
+import elite.intel.ai.mouth.AudioDeClicker;
+import elite.intel.ai.mouth.MainVoicePlaybackGate;
+import elite.intel.ai.mouth.MouthInterface;
+import elite.intel.ai.mouth.VocalisationHandle;
+import elite.intel.ai.mouth.subscribers.events.AiVoxResponseEvent;
+import elite.intel.ai.mouth.subscribers.events.BaseVoxEvent;
+import elite.intel.ai.mouth.subscribers.events.TTSInterruptEvent;
+import elite.intel.ai.mouth.subscribers.events.VocalisationRequestEvent;
+import elite.intel.ai.mouth.subscribers.events.VocalisationSuccessfulEvent;
+import elite.intel.eventbus.GameEventBus;
+import elite.intel.eventbus.UiBus;
+import elite.intel.i18n.Language;
+import elite.intel.session.PlayerSession;
+import elite.intel.session.SystemSession;
+import elite.intel.ui.event.AiResponseLogEvent;
+import elite.intel.ui.event.AppLogEvent;
+import elite.intel.ui.i18n.MultiLingualTextProvider;
+import elite.intel.util.AudioPlayer;
+import elite.intel.util.PlayBeepEvent;
+import elite.intel.util.StringUtls;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Microsoft Edge consumer Read Aloud mouth. A single synthesis worker downloads and decodes sentences ahead
+ * of a single playback worker, preserving request order while overlapping network work with speech output.
+ */
+public final class EdgeTTSImpl implements MouthInterface {
+    private static final Logger log = LogManager.getLogger(EdgeTTSImpl.class);
+    private static final EdgeTTSImpl INSTANCE = productionInstance();
+
+    private final BlockingQueue<SynthesisTask> synthesisQueue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<PlaybackTask> playbackQueue = new LinkedBlockingQueue<>();
+    private final AtomicBoolean interruptRequested = new AtomicBoolean();
+    private final AtomicBoolean voiceEnumerationAttempted = new AtomicBoolean();
+    private final AtomicLong interruptGeneration = new AtomicLong();
+    private final AtomicReference<SynthesisTask> currentSynthesis = new AtomicReference<>();
+    private final AtomicReference<SynthesisTask> currentNetworkSynthesis = new AtomicReference<>();
+    private final AtomicReference<PlaybackTask> currentPlayback = new AtomicReference<>();
+    private final EdgeSynthesisClient client;
+    private final EdgeAudioDecoder decoder;
+    private final EdgeVoiceProvider voiceProvider;
+    private final EdgeAudioOutput audioOutput;
+    private final EdgeTtsSettings settings;
+    private final boolean publishStartupEvents;
+
+    private volatile boolean running;
+    private Thread synthesisThread;
+    private Thread playbackThread;
+
+    private record SynthesisTask(
+            String text,
+            String selectedVoiceName,
+            Language language,
+            String rate,
+            float gain,
+            Class<? extends BaseVoxEvent> originType,
+            long generation,
+            boolean lastSentence,
+            VocalisationHandle handle
+    ) {
+    }
+
+    private record PlaybackTask(
+            String text,
+            String voiceName,
+            byte[] pcm,
+            Class<? extends BaseVoxEvent> originType,
+            long generation,
+            boolean lastSentence,
+            VocalisationHandle handle
+    ) {
+    }
+
+    private EdgeTTSImpl(
+            EdgeSynthesisClient client,
+            EdgeAudioDecoder decoder,
+            EdgeVoiceProvider voiceProvider,
+            EdgeAudioOutput audioOutput,
+            EdgeTtsSettings settings,
+            boolean publishStartupEvents
+    ) {
+        this.client = client;
+        this.decoder = decoder;
+        this.voiceProvider = voiceProvider;
+        this.audioOutput = audioOutput;
+        this.settings = settings;
+        this.publishStartupEvents = publishStartupEvents;
+    }
+
+    EdgeTTSImpl(
+            EdgeSynthesisClient client,
+            EdgeAudioDecoder decoder,
+            EdgeVoiceProvider voiceProvider,
+            EdgeAudioOutput audioOutput,
+            EdgeTtsSettings settings
+    ) {
+        this(client, decoder, voiceProvider, audioOutput, settings, false);
+    }
+
+    public static EdgeTTSImpl getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public synchronized void start() {
+        if (running) {
+            return;
+        }
+        if (!workersStopped()) {
+            log.error("Edge TTS cannot restart while a previous worker is still stopping");
+            return;
+        }
+        try {
+            audioOutput.open();
+        } catch (Exception e) {
+            log.error("Edge TTS failed to open the configured audio output", e);
+            UiBus.publish(new AppLogEvent("Edge TTS failed to start: " + e.getMessage()));
+            return;
+        }
+
+        completeQueuedSpeech();
+        interruptRequested.set(false);
+        voiceEnumerationAttempted.set(false);
+        running = true;
+        startWorkers();
+        GameEventBus.register(this);
+        log.info("Edge Read Aloud TTS started");
+        if (publishStartupEvents) {
+            publishStartupEvents();
+        }
+    }
+
+    @Override
+    public synchronized void stop() {
+        unregister();
+        running = false;
+        interruptGeneration.incrementAndGet();
+        interruptRequested.set(true);
+        client.cancelAll();
+        completeAllSpeech();
+        audioOutput.interrupt();
+        interruptWorkers();
+        joinWorkers();
+        audioOutput.close();
+        voiceProvider.clear();
+        synthesisThread = stoppedReference(synthesisThread);
+        playbackThread = stoppedReference(playbackThread);
+        log.info("Edge Read Aloud TTS stopped");
+    }
+
+    @Override
+    public void interruptAndClear() {
+        interruptGeneration.incrementAndGet();
+        interruptRequests(null);
+        log.info("Edge TTS interrupted and queues cleared");
+    }
+
+    @Subscribe
+    public void shutUp(TTSInterruptEvent event) {
+        if (event.requestId() == null) {
+            interruptAndClear();
+        } else {
+            interruptRequests(event.requestId());
+        }
+    }
+
+    @Subscribe
+    @Override
+    public synchronized void onVoiceProcessEvent(VocalisationRequestEvent event) {
+        // Radio remains on the dedicated Kokoro route, including when Edge is the main cloud mouth.
+        if (event.isRadio() || !running) {
+            return;
+        }
+        VocalisationHandle handle = event.handle();
+        if (!handle.claimForPlayback()) {
+            return;
+        }
+        try {
+            enqueue(event, handle);
+        } catch (RuntimeException e) {
+            handle.fail(e);
+            log.error("Failed to enqueue Edge TTS request", e);
+        }
+    }
+
+    private void enqueue(VocalisationRequestEvent event, VocalisationHandle handle) {
+        String text = preprocess(StringUtls.sanitizeTts(event.getText(), false));
+        List<String> sentences = EdgeSentenceSplitter.split(text);
+        if (sentences.isEmpty()) {
+            throw new IllegalArgumentException("Vocalisation text is blank after TTS sanitization");
+        }
+
+        String selected = event.getVoiceName() == null
+                ? settings.selectedVoiceName()
+                : EdgeVoices.femaleShortNameOrDefault(event.getVoiceName());
+        Language language = settings.language();
+        String rate = EdgeSsml.rate(settings.speechSpeed());
+        float gain = Math.max(0, Math.min(100, settings.voiceVolume())) / 100f;
+        long generation = interruptGeneration.get();
+        for (int i = 0; i < sentences.size(); i++) {
+            synthesisQueue.add(new SynthesisTask(
+                    sentences.get(i), selected, language, rate, gain,
+                    event.getOriginType(), generation, i == sentences.size() - 1, handle));
+        }
+        publishAccepted(event);
+    }
+
+    private void publishAccepted(VocalisationRequestEvent event) {
+        GameEventBus.publish(new PlayBeepEvent(AudioPlayer.BEEP_2));
+        UiBus.publish(new AiResponseLogEvent(event.getText(), event.getSpeaker()));
+    }
+
+    private void processSynthesisQueue() {
+        while (running) {
+            SynthesisTask task = null;
+            try {
+                task = synthesisQueue.take();
+                currentSynthesis.set(task);
+                if (isObsolete(task.handle(), task.generation())) {
+                    continue;
+                }
+                synthesize(task);
+            } catch (InterruptedException e) {
+                if (task != null) {
+                    task.handle().complete();
+                }
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                // WHY: this is the worker boundary; one provider/decoder failure must settle its handle without
+                // orphaning the service threads or preventing later independent requests from being processed.
+                if (task != null && !task.handle().isDone()) {
+                    failRequest(task, e);
+                    log.error("Edge TTS synthesis failed", e);
+                } else {
+                    log.debug("Edge TTS synthesis ended after cancellation", e);
+                }
+            } finally {
+                if (task != null) {
+                    currentSynthesis.compareAndSet(task, null);
+                }
+            }
+        }
+    }
+
+    private void synthesize(SynthesisTask task) throws Exception {
+        refreshVoicesIfNeeded();
+        if (isObsolete(task.handle(), task.generation())) {
+            return;
+        }
+        EdgeVoice voice = voiceProvider.resolve(task.selectedVoiceName(), task.language());
+        EdgeSynthesisRequest request = new EdgeSynthesisRequest(
+                task.handle().requestId(), task.text(), voice, task.rate(),
+                EdgeSsml.volume(100), EdgeSsml.pitch(0));
+        byte[] compressed;
+        currentNetworkSynthesis.set(task);
+        try {
+            if (isObsolete(task.handle(), task.generation())) {
+                return;
+            }
+            compressed = client.synthesize(request);
+        } finally {
+            currentNetworkSynthesis.compareAndSet(task, null);
+        }
+        if (isObsolete(task.handle(), task.generation())) {
+            return;
+        }
+        byte[] pcm = decoder.decode(compressed);
+        validatePcm(pcm);
+        if (isObsolete(task.handle(), task.generation())) {
+            return;
+        }
+        AudioDeClicker.sanitize(pcm, 6);
+        AudioDeClicker.applyVolume(pcm, task.gain());
+        if (isObsolete(task.handle(), task.generation())) {
+            return;
+        }
+        playbackQueue.put(new PlaybackTask(
+                task.text(), voice.shortName(), pcm, task.originType(), task.generation(),
+                task.lastSentence(), task.handle()));
+    }
+
+    private void refreshVoicesIfNeeded() throws InterruptedException {
+        if (voiceProvider.hasAvailableVoices() || !voiceEnumerationAttempted.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            voiceProvider.setAvailableVoices(client.listVoices());
+        } catch (java.io.IOException e) {
+            // WHY: voice enumeration is an optional enhancement. Known stable fallback voices keep TTS usable
+            // during a transient list-endpoint failure, while synthesis failures still fail the request.
+            log.warn("Could not enumerate Edge Read Aloud voices; using deterministic fallback: {}", e.getMessage());
+        }
+    }
+
+    private void processPlaybackQueue() {
+        while (running) {
+            PlaybackTask task = null;
+            try {
+                task = playbackQueue.take();
+                currentPlayback.set(task);
+                if (isObsolete(task.handle(), task.generation())) {
+                    continue;
+                }
+                boolean completed = play(task);
+                if (completed && task.lastSentence()) {
+                    task.handle().complete();
+                }
+            } catch (InterruptedException e) {
+                if (task != null) {
+                    task.handle().complete();
+                }
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                // WHY: this is the playback worker boundary; a device failure settles the affected request and
+                // keeps the worker available for a later request if the device recovers.
+                if (task != null && !task.handle().isDone()) {
+                    task.handle().fail(e);
+                }
+                log.error("Edge TTS playback failed", e);
+            } finally {
+                if (task != null) {
+                    currentPlayback.compareAndSet(task, null);
+                }
+                UiBus.publish(new AppLogEvent(""));
+            }
+        }
+    }
+
+    private boolean play(PlaybackTask task) throws Exception {
+        MainVoicePlaybackGate.begin();
+        try {
+            boolean completed = audioOutput.play(task.pcm(), () -> interruptRequested.get()
+                    || task.handle().isDone()
+                    || (task.handle().interruptible() && task.generation() != interruptGeneration.get()));
+            if (completed) {
+                log.info("Spoke with Edge voice {}: {}", task.voiceName(), task.text());
+                publishCompletionEvent(task.originType());
+            }
+            return completed;
+        } finally {
+            interruptRequested.set(false);
+            MainVoicePlaybackGate.end();
+        }
+    }
+
+    private void interruptRequests(String requestId) {
+        long liveGeneration = interruptGeneration.get();
+        removeInterruptedSynthesis(requestId, liveGeneration);
+        removeInterruptedPlayback(requestId, liveGeneration);
+
+        SynthesisTask synthesis = currentSynthesis.get();
+        if (synthesis != null && shouldInterrupt(
+                synthesis.handle(), synthesis.generation(), requestId, liveGeneration)) {
+            synthesis.handle().complete();
+            SynthesisTask network = currentNetworkSynthesis.get();
+            if (network == synthesis) {
+                client.cancel(synthesis.handle().requestId());
+            }
+        }
+        PlaybackTask playback = currentPlayback.get();
+        if (playback == null || !shouldInterrupt(
+                playback.handle(), playback.generation(), requestId, liveGeneration)) {
+            return;
+        }
+        playback.handle().complete();
+        interruptRequested.set(true);
+        audioOutput.interrupt();
+    }
+
+    private void removeInterruptedSynthesis(String requestId, long liveGeneration) {
+        for (SynthesisTask task : new ArrayList<>(synthesisQueue)) {
+            if (shouldInterrupt(task.handle(), task.generation(), requestId, liveGeneration)
+                    && synthesisQueue.remove(task)) {
+                task.handle().complete();
+            }
+        }
+    }
+
+    private void removeInterruptedPlayback(String requestId, long liveGeneration) {
+        for (PlaybackTask task : new ArrayList<>(playbackQueue)) {
+            if (shouldInterrupt(task.handle(), task.generation(), requestId, liveGeneration)
+                    && playbackQueue.remove(task)) {
+                task.handle().complete();
+            }
+        }
+    }
+
+    private static boolean shouldInterrupt(
+            VocalisationHandle handle,
+            long taskGeneration,
+            String requestId,
+            long liveGeneration
+    ) {
+        if (!handle.interruptible()) {
+            return false;
+        }
+        return requestId == null
+                ? taskGeneration != liveGeneration
+                : requestId.equals(handle.requestId());
+    }
+
+    private boolean isObsolete(VocalisationHandle handle, long taskGeneration) {
+        if (handle.isDone()) {
+            return true;
+        }
+        if (handle.interruptible() && taskGeneration != interruptGeneration.get()) {
+            handle.complete();
+            return true;
+        }
+        return false;
+    }
+
+    private void startWorkers() {
+        synthesisThread = new Thread(this::processSynthesisQueue, "EdgeTTS-Synthesis");
+        synthesisThread.setDaemon(true);
+        synthesisThread.start();
+        playbackThread = new Thread(this::processPlaybackQueue, "EdgeTTS-Playback");
+        playbackThread.setDaemon(true);
+        playbackThread.start();
+    }
+
+    private void interruptWorkers() {
+        if (synthesisThread != null) {
+            synthesisThread.interrupt();
+        }
+        if (playbackThread != null) {
+            playbackThread.interrupt();
+        }
+    }
+
+    private void joinWorkers() {
+        joinWorker(synthesisThread);
+        joinWorker(playbackThread);
+    }
+
+    private static void joinWorker(Thread worker) {
+        if (worker == null) {
+            return;
+        }
+        try {
+            worker.join(5_000);
+            if (worker.isAlive()) {
+                log.error("Edge TTS worker did not stop deterministically: {}", worker.getName());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while stopping Edge TTS worker {}", worker.getName(), e);
+        }
+    }
+
+    private static Thread stoppedReference(Thread worker) {
+        return worker == null || !worker.isAlive() ? null : worker;
+    }
+
+    private void completeQueuedSpeech() {
+        List<SynthesisTask> synthesis = new ArrayList<>();
+        synthesisQueue.drainTo(synthesis);
+        synthesis.forEach(task -> task.handle().complete());
+        List<PlaybackTask> playback = new ArrayList<>();
+        playbackQueue.drainTo(playback);
+        playback.forEach(task -> task.handle().complete());
+    }
+
+    private void completeAllSpeech() {
+        completeQueuedSpeech();
+        SynthesisTask synthesis = currentSynthesis.get();
+        if (synthesis != null) {
+            synthesis.handle().complete();
+        }
+        PlaybackTask playback = currentPlayback.get();
+        if (playback != null) {
+            playback.handle().complete();
+        }
+    }
+
+    private void failRequest(SynthesisTask failed, Exception failure) {
+        failed.handle().fail(failure);
+        synthesisQueue.removeIf(task -> task.handle() == failed.handle());
+        playbackQueue.removeIf(task -> task.handle() == failed.handle());
+        PlaybackTask playback = currentPlayback.get();
+        if (playback != null && playback.handle() == failed.handle()) {
+            interruptRequested.set(true);
+            audioOutput.interrupt();
+        }
+    }
+
+    private void unregister() {
+        try {
+            GameEventBus.unregister(this);
+        } catch (IllegalArgumentException ignored) {
+            log.debug("Edge TTS was already unregistered");
+        }
+    }
+
+    private void publishStartupEvents() {
+        SystemSession systemSession = SystemSession.getInstance();
+        if (systemSession.getRmsThresholdHigh() != null) {
+            UiBus.publish(new AiResponseLogEvent(MultiLingualTextProvider.getText("speech.enabled")));
+        }
+        String playerName = PlayerSession.getInstance().getConfiguredPlayerName();
+        GameEventBus.publish(new AiVoxResponseEvent(StringUtls.greeting(playerName)));
+    }
+
+    private void publishCompletionEvent(Class<? extends BaseVoxEvent> originType) {
+        try {
+            GameEventBus.publish(new VocalisationSuccessfulEvent<>(
+                    originType.getConstructor(String.class).newInstance("")));
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+                 | NoSuchMethodException e) {
+            log.error("Failed to publish Edge VocalisationSuccessfulEvent", e);
+        }
+    }
+
+    private static String preprocess(String text) {
+        return text.replace("present", "detected").replace("_", " ").replace("*", "");
+    }
+
+    private static void validatePcm(byte[] pcm) {
+        if (pcm == null || pcm.length == 0 || (pcm.length & 1) != 0) {
+            throw new IllegalStateException("Edge MP3 decoder returned invalid PCM-16 audio");
+        }
+    }
+
+    boolean workersStopped() {
+        return (synthesisThread == null || !synthesisThread.isAlive())
+                && (playbackThread == null || !playbackThread.isAlive());
+    }
+
+    private static EdgeTTSImpl productionInstance() {
+        SystemSession session = SystemSession.getInstance();
+        return new EdgeTTSImpl(
+                new EdgeReadAloudClient(),
+                new EdgeMp3Decoder(),
+                new EdgeVoiceProvider(),
+                new JavaSoundEdgeAudioOutput(session::getAudioOutputDevice),
+                EdgeTtsSettings.system(),
+                true);
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeTtsSettings.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeTtsSettings.java
@@ -1,0 +1,41 @@
+package elite.intel.ai.mouth.edge;
+
+import elite.intel.i18n.Language;
+import elite.intel.session.SystemSession;
+
+/** Reads only the application settings Edge synthesis needs and provides an injectable test seam. */
+interface EdgeTtsSettings {
+    String selectedVoiceName();
+
+    Language language();
+
+    float speechSpeed();
+
+    int voiceVolume();
+
+    static EdgeTtsSettings system() {
+        SystemSession session = SystemSession.getInstance();
+        return new EdgeTtsSettings() {
+            @Override
+            public String selectedVoiceName() {
+                return session.getEdgeVoiceName();
+            }
+
+            @Override
+            public Language language() {
+                return session.getLanguage();
+            }
+
+            @Override
+            public float speechSpeed() {
+                Float speed = session.getSpeechSpeed();
+                return speed == null ? 0f : speed;
+            }
+
+            @Override
+            public int voiceVolume() {
+                return session.getVoiceVolume();
+            }
+        };
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoice.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoice.java
@@ -1,0 +1,24 @@
+package elite.intel.ai.mouth.edge;
+
+/** One voice returned by Microsoft Edge's Read Aloud voice-list endpoint. */
+record EdgeVoice(String name, String shortName, String gender, String locale, String suggestedCodec) {
+    EdgeVoice {
+        if (shortName == null || shortName.isBlank()) {
+            throw new IllegalArgumentException("Edge voice ShortName must not be blank");
+        }
+        if (gender == null || gender.isBlank()) {
+            throw new IllegalArgumentException("Edge voice Gender must not be blank");
+        }
+        if (locale == null || locale.isBlank()) {
+            throw new IllegalArgumentException("Edge voice Locale must not be blank");
+        }
+    }
+
+    boolean male() {
+        return "Male".equalsIgnoreCase(gender);
+    }
+
+    String protocolName() {
+        return name == null || name.isBlank() ? EdgeSsml.protocolVoiceName(shortName) : name;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoiceListParser.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoiceListParser.java
@@ -1,0 +1,59 @@
+package elite.intel.ai.mouth.edge;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Strictly maps the Edge voice-list JSON into typed voice records. */
+final class EdgeVoiceListParser {
+    private EdgeVoiceListParser() {
+    }
+
+    static List<EdgeVoice> parse(String json) throws EdgeProtocolException {
+        try {
+            JsonElement root = JsonParser.parseString(json);
+            if (!root.isJsonArray()) {
+                throw new EdgeProtocolException("Edge voice-list response is not an array");
+            }
+            JsonArray array = root.getAsJsonArray();
+            List<EdgeVoice> voices = new ArrayList<>(array.size());
+            for (JsonElement element : array) {
+                if (!element.isJsonObject()) {
+                    throw new EdgeProtocolException("Edge voice-list entry is not an object");
+                }
+                JsonObject voice = element.getAsJsonObject();
+                voices.add(new EdgeVoice(
+                        optionalString(voice, "Name"),
+                        requiredString(voice, "ShortName"),
+                        requiredString(voice, "Gender"),
+                        requiredString(voice, "Locale"),
+                        optionalString(voice, "SuggestedCodec")));
+            }
+            if (voices.isEmpty()) {
+                throw new EdgeProtocolException("Edge voice-list response is empty");
+            }
+            return List.copyOf(voices);
+        } catch (EdgeProtocolException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new EdgeProtocolException("Malformed Edge voice-list response", e);
+        }
+    }
+
+    private static String requiredString(JsonObject object, String field) throws EdgeProtocolException {
+        String value = optionalString(object, field);
+        if (value == null || value.isBlank()) {
+            throw new EdgeProtocolException("Edge voice-list entry is missing " + field);
+        }
+        return value;
+    }
+
+    private static String optionalString(JsonObject object, String field) {
+        JsonElement value = object.get(field);
+        return value == null || value.isJsonNull() ? null : value.getAsString();
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoiceProvider.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoiceProvider.java
@@ -1,0 +1,104 @@
+package elite.intel.ai.mouth.edge;
+
+import elite.intel.i18n.Language;
+
+import java.util.List;
+
+/** Resolves the per-ship voice model against the voices currently offered by Edge Read Aloud. */
+final class EdgeVoiceProvider {
+    private volatile List<EdgeVoice> availableVoices = List.of();
+
+    void setAvailableVoices(List<EdgeVoice> voices) {
+        if (voices == null || voices.isEmpty()) {
+            throw new IllegalArgumentException("Edge available voices must not be empty");
+        }
+        availableVoices = List.copyOf(voices);
+    }
+
+    boolean hasAvailableVoices() {
+        return !availableVoices.isEmpty();
+    }
+
+    void clear() {
+        availableVoices = List.of();
+    }
+
+    EdgeVoice resolve(String selectedName, Language language) {
+        EdgeVoices mapped = EdgeVoices.find(selectedName);
+        String desired = mapped == null ? selectedName : mapped.defaultShortName();
+        if (mapped != null && mapped.male()) {
+            mapped = EdgeVoices.DEFAULT_FEMALE;
+            desired = mapped.defaultShortName();
+        }
+        List<EdgeVoice> voices = availableVoices;
+        if (desired != null) {
+            String requested = desired;
+            EdgeVoice exact = voices.stream()
+                    .filter(voice -> voice.shortName().equals(requested))
+                    .filter(voice -> languageMatches(language, voice.locale()))
+                    .filter(voice -> !voice.male())
+                    .findFirst()
+                    .orElse(null);
+            if (exact != null) {
+                return exact;
+            }
+        }
+
+        List<EdgeVoice> candidates = voices.stream()
+                .filter(voice -> languageMatches(language, voice.locale()))
+                .filter(voice -> !voice.male())
+                .sorted((left, right) -> left.shortName().compareTo(right.shortName()))
+                .toList();
+        if (!candidates.isEmpty()) {
+            int selection = mapped == null || selectedName == null ? 0 : mapped.ordinal();
+            if (mapped == null && selectedName != null) {
+                selection = selectedName.hashCode();
+            }
+            return candidates.get(Math.floorMod(selection, candidates.size()));
+        }
+        String fallback = language == Language.EN
+                ? (mapped == null ? EdgeVoices.DEFAULT_FEMALE.defaultShortName() : mapped.defaultShortName())
+                : localizedFallback(language);
+        return fallbackVoice(fallback, locale(language));
+    }
+
+    private static EdgeVoice fallbackVoice(String shortName, String locale) {
+        return new EdgeVoice(
+                EdgeSsml.protocolVoiceName(shortName), shortName, "Female", locale,
+                EdgeProtocolConstants.OUTPUT_FORMAT);
+    }
+
+    private static boolean languageMatches(Language language, String locale) {
+        return language == Language.EN
+                ? locale.regionMatches(true, 0, "en-", 0, 3)
+                : locale.equalsIgnoreCase(locale(language));
+    }
+
+    private static String locale(Language language) {
+        return switch (language) {
+            case EN -> "en-US";
+            case RU -> "ru-RU";
+            case UK -> "uk-UA";
+            case DE -> "de-DE";
+            case FR -> "fr-FR";
+            case ES -> "es-ES";
+            case IT -> "it-IT";
+            case PT -> "pt-PT";
+            case PTBZ -> "pt-BR";
+        };
+    }
+
+    private static String localizedFallback(Language language) {
+        return switch (language) {
+            case EN -> "en-US-EmmaMultilingualNeural";
+            case RU -> "ru-RU-SvetlanaNeural";
+            case UK -> "uk-UA-PolinaNeural";
+            case DE -> "de-DE-KatjaNeural";
+            case FR -> "fr-FR-DeniseNeural";
+            case ES -> "es-ES-ElviraNeural";
+            case IT -> "it-IT-ElsaNeural";
+            case PT -> "pt-PT-RaquelNeural";
+            case PTBZ -> "pt-BR-FranciscaNeural";
+        };
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoices.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/EdgeVoices.java
@@ -1,0 +1,79 @@
+package elite.intel.ai.mouth.edge;
+
+/**
+ * Maps the existing per-ship voice names to stable Edge Read Aloud voices. The enum names intentionally match
+ * the cloud voice choices already persisted for Google, so selecting {@code edge://} needs no new UI control or
+ * database representation.
+ */
+public enum EdgeVoices {
+    MARY("Mary", false, "en-US-EmmaMultilingualNeural"),
+    ANNA("Anna", false, "en-GB-SoniaNeural"),
+    EMMA("Emma", false, "en-US-AriaNeural"),
+    JAKE("Jake", true, "en-US-GuyNeural"),
+    JAMES("James", true, "en-AU-WilliamNeural"),
+    JENNIFER("Jennifer", false, "en-US-JennyNeural"),
+    JOSEPH("Joseph", true, "en-US-DavisNeural"),
+    MICHAEL("Michael", true, "en-US-ChristopherNeural"),
+    OLIVIA("Olivia", false, "en-GB-LibbyNeural"),
+    RACHEL("Rachel", false, "en-US-AvaMultilingualNeural"),
+    STEVE("Steve", true, "en-US-BrianNeural");
+
+    public static final EdgeVoices DEFAULT_FEMALE = MARY;
+
+    private final String displayName;
+    private final boolean male;
+    private final String defaultShortName;
+
+    EdgeVoices(String displayName, boolean male, String defaultShortName) {
+        this.displayName = displayName;
+        this.male = male;
+        this.defaultShortName = defaultShortName;
+    }
+
+    public static EdgeVoices femaleOrDefault(String name) {
+        EdgeVoices voice = fromName(name, DEFAULT_FEMALE);
+        return voice.male ? DEFAULT_FEMALE : voice;
+    }
+
+    /** Maps a legacy display/enum name to Edge's ShortName while preserving provider-native ShortNames. */
+    public static String femaleShortNameOrDefault(String name) {
+        EdgeVoices mapped = find(name);
+        if (mapped != null) {
+            return mapped.male ? DEFAULT_FEMALE.defaultShortName : mapped.defaultShortName;
+        }
+        if (name != null && !name.isBlank() && name.endsWith("Neural")) {
+            return name;
+        }
+        return DEFAULT_FEMALE.defaultShortName;
+    }
+
+    static EdgeVoices fromName(String name, EdgeVoices fallback) {
+        EdgeVoices voice = find(name);
+        return voice == null ? fallback : voice;
+    }
+
+    static EdgeVoices find(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        for (EdgeVoices voice : values()) {
+            if (voice.name().equalsIgnoreCase(name) || voice.displayName.equalsIgnoreCase(name)
+                    || voice.defaultShortName.equals(name)) {
+                return voice;
+            }
+        }
+        return null;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public boolean male() {
+        return male;
+    }
+
+    public String defaultShortName() {
+        return defaultShortName;
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/edge/JavaSoundEdgeAudioOutput.java
+++ b/app/src/main/java/elite/intel/ai/mouth/edge/JavaSoundEdgeAudioOutput.java
@@ -1,0 +1,116 @@
+package elite.intel.ai.mouth.edge;
+
+import elite.intel.ai.ears.AudioDeviceEnumerator;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.DataLine;
+import javax.sound.sampled.Mixer;
+import javax.sound.sampled.SourceDataLine;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/** Persistent Java Sound output line for the application's required PCM format and configured mixer. */
+final class JavaSoundEdgeAudioOutput implements EdgeAudioOutput {
+    @FunctionalInterface
+    interface LineFactory {
+        SourceDataLine create(DataLine.Info info, Mixer.Info mixer) throws Exception;
+    }
+
+    private final Supplier<String> outputDevice;
+    private final LineFactory lineFactory;
+    private final AtomicReference<SourceDataLine> line = new AtomicReference<>();
+
+    JavaSoundEdgeAudioOutput(Supplier<String> outputDevice) {
+        this(outputDevice, AudioDeviceEnumerator::openOutputLine);
+    }
+
+    JavaSoundEdgeAudioOutput(Supplier<String> outputDevice, LineFactory lineFactory) {
+        this.outputDevice = outputDevice;
+        this.lineFactory = lineFactory;
+    }
+
+    @Override
+    public synchronized void open() throws Exception {
+        SourceDataLine current = line.get();
+        if (current != null && current.isOpen()) {
+            return;
+        }
+        if (current != null) {
+            current.close();
+            line.compareAndSet(current, null);
+        }
+        AudioFormat format = new AudioFormat(EdgeProtocolConstants.SAMPLE_RATE, 16, 1, true, false);
+        DataLine.Info info = new DataLine.Info(SourceDataLine.class, format);
+        Mixer.Info mixer = AudioDeviceEnumerator.resolveOutputDevice(outputDevice.get());
+        SourceDataLine opened = lineFactory.create(info, mixer);
+        int bufferBytes = (int) (format.getFrameSize() * format.getSampleRate() / 10);
+        try {
+            opened.open(format, bufferBytes);
+            opened.start();
+            line.set(opened);
+        } catch (Exception | Error failure) {
+            try {
+                opened.close();
+            } catch (RuntimeException closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
+    }
+
+    @Override
+    public boolean play(byte[] pcm, BooleanSupplier interrupted) {
+        SourceDataLine current = line.get();
+        if (current == null || !current.isOpen()) {
+            throw new IllegalStateException("Edge TTS audio output is unavailable");
+        }
+        AudioFormat format = current.getFormat();
+        int frameSize = format.getFrameSize();
+        int bufferBytes = (int) (format.getFrameSize() * format.getSampleRate() / 10);
+        byte[] silence = new byte[(int) (format.getSampleRate() * 0.03f) * frameSize];
+        current.write(silence, 0, silence.length);
+        for (int offset = 0; offset < pcm.length; offset += bufferBytes) {
+            if (interrupted.getAsBoolean()) {
+                current.flush();
+                return false;
+            }
+            int length = Math.min(bufferBytes, pcm.length - offset);
+            length -= length % frameSize;
+            if (length > 0) {
+                current.write(pcm, offset, length);
+            }
+        }
+        if (interrupted.getAsBoolean()) {
+            current.flush();
+            return false;
+        }
+        current.drain();
+        return true;
+    }
+
+    @Override
+    public void interrupt() {
+        SourceDataLine current = line.get();
+        if (current == null || !current.isOpen()) {
+            return;
+        }
+        current.stop();
+        current.flush();
+        current.start();
+    }
+
+    @Override
+    public synchronized void close() {
+        SourceDataLine current = line.getAndSet(null);
+        if (current == null) {
+            return;
+        }
+        try {
+            current.stop();
+            current.flush();
+        } finally {
+            current.close();
+        }
+    }
+}

--- a/app/src/main/java/elite/intel/ai/mouth/subscribers/events/VocalisationRequestEvent.java
+++ b/app/src/main/java/elite/intel/ai/mouth/subscribers/events/VocalisationRequestEvent.java
@@ -73,9 +73,7 @@ public class VocalisationRequestEvent extends BaseVoxEvent {
         return canBeInterrupted;
     }
 
-    /**
-     * Voice name (enum name). Null means use the session default.
-     */
+    /** Voice identifier for the active provider (enum name or provider-native ShortName); null uses the default. */
     public String getVoiceName() {
         return voiceName;
     }

--- a/app/src/main/java/elite/intel/gameapi/journal/subscribers/LoadoutSubscriber.java
+++ b/app/src/main/java/elite/intel/gameapi/journal/subscribers/LoadoutSubscriber.java
@@ -1,7 +1,10 @@
 package elite.intel.gameapi.journal.subscribers;
 
 import com.google.common.eventbus.Subscribe;
+import elite.intel.ai.KeyDetector;
+import elite.intel.ai.ProviderEnum;
 import elite.intel.ai.mouth.EventNarrator;
+import elite.intel.ai.mouth.edge.EdgeVoices;
 import elite.intel.ai.mouth.google.GoogleVoices;
 import elite.intel.ai.mouth.kokoro.KokoroVoices;
 import elite.intel.db.dao.ShipDao;
@@ -50,7 +53,10 @@ public class LoadoutSubscriber {
 
                 String shipDefaultVoice = KokoroVoices.DEFAULT_FEMALE.name();
                 if (!systemSession.useLocalTTS()) {
-                    shipDefaultVoice = GoogleVoices.DEFAULT_FEMALE.name();
+                    ProviderEnum provider = KeyDetector.detectProvider(systemSession.getTtsApiKey(), "TTS");
+                    shipDefaultVoice = provider == ProviderEnum.EDGE_TTS
+                            ? EdgeVoices.DEFAULT_FEMALE.defaultShortName()
+                            : GoogleVoices.DEFAULT_FEMALE.name();
                 }
                 shipManager.save(event.getShipId(), shipName, event.getCargoCapacity(), event.getShip(), shipDefaultVoice,
                         hasCommander ? commanderName : null);

--- a/app/src/main/java/elite/intel/session/SystemSession.java
+++ b/app/src/main/java/elite/intel/session/SystemSession.java
@@ -1,6 +1,7 @@
 package elite.intel.session;
 
 import elite.intel.ai.brain.ShipPersonality;
+import elite.intel.ai.mouth.edge.EdgeVoices;
 import elite.intel.ai.mouth.google.GoogleVoices;
 import elite.intel.ai.mouth.kokoro.KokoroVoices;
 import elite.intel.db.dao.ChatHistoryDao;
@@ -55,6 +56,17 @@ public class SystemSession {
     public GoogleVoices getGoogleVoice() {
         ShipDao.Ship ship = shipManager.getShip();
         return GoogleVoices.femaleOrDefault(ship == null ? null : ship.getVoice());
+    }
+
+
+    public EdgeVoices getEdgeVoice() {
+        ShipDao.Ship ship = shipManager.getShip();
+        return EdgeVoices.femaleOrDefault(ship == null ? null : ship.getVoice());
+    }
+
+    public String getEdgeVoiceName() {
+        ShipDao.Ship ship = shipManager.getShip();
+        return EdgeVoices.femaleShortNameOrDefault(ship == null ? null : ship.getVoice());
     }
 
 

--- a/app/src/main/java/elite/intel/ui/screen/CommanderTabPanel.java
+++ b/app/src/main/java/elite/intel/ui/screen/CommanderTabPanel.java
@@ -1,7 +1,10 @@
 package elite.intel.ui.screen;
 
 import com.google.common.eventbus.Subscribe;
+import elite.intel.ai.KeyDetector;
+import elite.intel.ai.ProviderEnum;
 import elite.intel.ai.brain.ShipPersonality;
+import elite.intel.ai.mouth.edge.EdgeVoices;
 import elite.intel.ai.mouth.google.GoogleVoiceProvider;
 import elite.intel.ai.mouth.google.GoogleVoices;
 import elite.intel.ai.mouth.kokoro.KokoroVoices;
@@ -87,6 +90,10 @@ public class CommanderTabPanel extends JPanel {
             if (SystemSession.getInstance().useLocalTTS()) {
                 KokoroVoices v = KokoroVoices.valueOf(enumName);
                 return v.getDisplayName() + " - " + v.getDescription();
+            }
+            if (usesEdgeTts()) {
+                EdgeVoices voice = edgeVoice(enumName);
+                return voice == null ? enumName : voice.displayName() + " - " + voice.defaultShortName();
             }
             GoogleVoices v = GoogleVoices.valueOf(enumName);
             String base = v.getDisplayName() + " - " + googleVoiceDescriptor(v);
@@ -372,9 +379,17 @@ public class CommanderTabPanel extends JPanel {
         // Voice options depend on current TTS provider; rebuild editor on every call. Ship voices are
         // female-only (radio transmissions keep the full voice set), so the male voices are filtered out.
         boolean useLocal = SystemSession.getInstance().useLocalTTS();
-        String[] voiceOptions = useLocal
-                ? Arrays.stream(KokoroVoices.values()).filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new)
-                : Arrays.stream(GoogleVoices.values()).filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new);
+        String[] voiceOptions;
+        if (useLocal) {
+            voiceOptions = Arrays.stream(KokoroVoices.values())
+                    .filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new);
+        } else if (usesEdgeTts()) {
+            voiceOptions = Arrays.stream(EdgeVoices.values())
+                    .filter(v -> !v.male()).map(EdgeVoices::defaultShortName).toArray(String[]::new);
+        } else {
+            voiceOptions = Arrays.stream(GoogleVoices.values())
+                    .filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new);
+        }
         // labelFn shows "DisplayName - accent"; getCellEditorValue() still returns the raw enum name to store.
         fleetTable.getColumnModel().getColumn(COL_VOICE)
                 .setCellEditor(new HudComboCellEditor(new HudComboBox<>(voiceOptions, this::voiceLabel)));
@@ -393,12 +408,31 @@ public class CommanderTabPanel extends JPanel {
      * Normalizes a stored ship voice to a female voice for the active TTS provider. Ship voices are
      * female-only, so a legacy male (or otherwise invalid) stored voice resolves to the provider's default
      * female — keeping the fleet grid's displayed/selected voice a valid, female dropdown option and in step
-     * with what {@link SystemSession#getKokoroVoice()} / {@link SystemSession#getGoogleVoice()} actually speak.
+     * with what the active provider actually speaks.
      */
     static String normalizeVoiceToFemale(String voiceName) {
-        return SystemSession.getInstance().useLocalTTS()
-                ? KokoroVoices.femaleOrDefault(voiceName).name()
-                : GoogleVoices.femaleOrDefault(voiceName).name();
+        if (SystemSession.getInstance().useLocalTTS()) {
+            return KokoroVoices.femaleOrDefault(voiceName).name();
+        }
+        if (usesEdgeTts()) {
+            return EdgeVoices.femaleShortNameOrDefault(voiceName);
+        }
+        return GoogleVoices.femaleOrDefault(voiceName).name();
+    }
+
+    private static boolean usesEdgeTts() {
+        SystemSession session = SystemSession.getInstance();
+        return !session.useLocalTTS()
+                && KeyDetector.detectProvider(session.getTtsApiKey(), "TTS") == ProviderEnum.EDGE_TTS;
+    }
+
+    private static EdgeVoices edgeVoice(String name) {
+        return Arrays.stream(EdgeVoices.values())
+                .filter(voice -> voice.name().equalsIgnoreCase(name)
+                        || voice.displayName().equalsIgnoreCase(name)
+                        || voice.defaultShortName().equals(name))
+                .findFirst()
+                .orElse(null);
     }
 
     static String displayShipName(ShipDao.Ship ship) {

--- a/app/src/main/java/elite/intel/ui/screen/CommanderTabPanel.java
+++ b/app/src/main/java/elite/intel/ui/screen/CommanderTabPanel.java
@@ -78,9 +78,12 @@ public class CommanderTabPanel extends JPanel {
     }
 
     /**
-     * Maps a stored voice enum name to a readable "DisplayName - accent · quality" label, resolved against the
-     * active TTS provider's voices. The accent disambiguates voices that share a display name (e.g. Spanish vs
-     * Portuguese "Dora"); the quality tier (HD vs Standard) shows what the selected language actually delivers.
+     * Maps a stored voice enum name to a readable label, resolved against the active TTS provider's voices.
+     * Google/Kokoro show "DisplayName - accent · quality": the accent disambiguates voices that share a display
+     * name (e.g. Spanish vs Portuguese "Dora"), and the quality tier (HD vs Standard) shows what the selected
+     * language actually delivers. Edge shows "DisplayName - accent" using the same friendly descriptor Google
+     * uses for the same logical identity (see {@link #edgeVoiceLabel}) — the provider-native ShortName (e.g.
+     * "en-US-EmmaMultilingualNeural") is an implementation detail and must never leak into this UI.
      * Falls back to the raw name when the stored voice is not valid for the active provider (for example after
      * a TTS provider switch).
      */
@@ -92,8 +95,7 @@ public class CommanderTabPanel extends JPanel {
                 return v.getDisplayName() + " - " + v.getDescription();
             }
             if (usesEdgeTts()) {
-                EdgeVoices voice = edgeVoice(enumName);
-                return voice == null ? enumName : voice.displayName() + " - " + voice.defaultShortName();
+                return edgeVoiceLabel(enumName);
             }
             GoogleVoices v = GoogleVoices.valueOf(enumName);
             String base = v.getDisplayName() + " - " + googleVoiceDescriptor(v);
@@ -109,6 +111,10 @@ public class CommanderTabPanel extends JPanel {
      * Fleet-label descriptor for a Google voice. In English the accent (American/British/Australian) tells the
      * voices apart; in any other language every Google voice is synthesized in that language (its Chirp3-HD
      * character), so only the localized gender is shown instead of a misleading English accent.
+     * <p>
+     * Also reused for Edge (see {@link #edgeVoiceLabel}): {@link EdgeVoices} enum names intentionally match
+     * {@link GoogleVoices} one-for-one with the same accents, so the two providers show identical descriptors
+     * for the same logical identity rather than duplicating the "American female" / "British female" literals.
      */
     private static String googleVoiceDescriptor(GoogleVoices v) {
         if (SystemSession.getInstance().getLanguage() == Language.EN) {
@@ -385,7 +391,7 @@ public class CommanderTabPanel extends JPanel {
                     .filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new);
         } else if (usesEdgeTts()) {
             voiceOptions = Arrays.stream(EdgeVoices.values())
-                    .filter(v -> !v.male()).map(EdgeVoices::defaultShortName).toArray(String[]::new);
+                    .filter(v -> !v.male()).map(Enum::name).toArray(String[]::new);
         } else {
             voiceOptions = Arrays.stream(GoogleVoices.values())
                     .filter(v -> !v.isMale()).map(Enum::name).toArray(String[]::new);
@@ -415,7 +421,7 @@ public class CommanderTabPanel extends JPanel {
             return KokoroVoices.femaleOrDefault(voiceName).name();
         }
         if (usesEdgeTts()) {
-            return EdgeVoices.femaleShortNameOrDefault(voiceName);
+            return EdgeVoices.femaleOrDefault(voiceName).name();
         }
         return GoogleVoices.femaleOrDefault(voiceName).name();
     }
@@ -433,6 +439,22 @@ public class CommanderTabPanel extends JPanel {
                         || voice.defaultShortName().equals(name))
                 .findFirst()
                 .orElse(null);
+    }
+
+    /**
+     * Fleet-label for an Edge voice: "DisplayName - accent · gender" (e.g. "Mary - American female"), the same
+     * friendly format Google already uses for the same logical identity - see {@link #googleVoiceDescriptor}.
+     * {@link EdgeVoices} and {@link GoogleVoices} enum names match one-for-one by design, so the descriptor is
+     * looked up from {@link GoogleVoices} rather than duplicating "American female" / "British female" literals
+     * in {@link EdgeVoices}. Edge's provider-native ShortName (e.g. "en-US-EmmaMultilingualNeural") is an
+     * implementation detail of how the logical name is resolved for synthesis and must never appear in this UI.
+     * Accepts either the logical enum name or a legacy ShortName (both resolve via {@link #edgeVoice}), so a
+     * stored value in either form still renders as just the friendly logical label.
+     */
+    static String edgeVoiceLabel(String enumName) {
+        EdgeVoices voice = edgeVoice(enumName);
+        if (voice == null) return enumName;
+        return voice.displayName() + " - " + googleVoiceDescriptor(GoogleVoices.valueOf(voice.name()));
     }
 
     static String displayShipName(ShipDao.Ship ship) {

--- a/app/src/main/java/elite/intel/ui/screen/settings/AiServicesSettingsPanel.java
+++ b/app/src/main/java/elite/intel/ui/screen/settings/AiServicesSettingsPanel.java
@@ -1,5 +1,8 @@
 package elite.intel.ui.screen.settings;
 
+import elite.intel.ai.KeyDetector;
+import elite.intel.ai.ProviderEnum;
+import elite.intel.ai.mouth.edge.EdgeVoices;
 import elite.intel.ai.mouth.google.GoogleVoices;
 import elite.intel.ai.mouth.kokoro.KokoroVoices;
 import elite.intel.db.managers.ShipManager;
@@ -362,7 +365,14 @@ public class AiServicesSettingsPanel extends JPanel {
             if (!confirmed) {
                 return false; // abort entire save, stay in editing state
             }
-            String defaultVoice = newTtsLocal ? KokoroVoices.DEFAULT_FEMALE.name() : GoogleVoices.DEFAULT_FEMALE.name();
+            String defaultVoice;
+            if (newTtsLocal) {
+                defaultVoice = KokoroVoices.DEFAULT_FEMALE.name();
+            } else if (KeyDetector.detectProvider(newTtsKey, "TTS") == ProviderEnum.EDGE_TTS) {
+                defaultVoice = EdgeVoices.DEFAULT_FEMALE.defaultShortName();
+            } else {
+                defaultVoice = GoogleVoices.DEFAULT_FEMALE.name();
+            }
             ShipManager.getInstance().resetAllVoicesToDefault(defaultVoice);
         }
 

--- a/app/src/main/resources/META-INF/licenses/java-audio-stack-LGPL-3.0.txt
+++ b/app/src/main/resources/META-INF/licenses/java-audio-stack-LGPL-3.0.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/app/src/main/resources/META-INF/licenses/jlayer-decoder-LGPL-2.1.txt
+++ b/app/src/main/resources/META-INF/licenses/jlayer-decoder-LGPL-2.1.txt
@@ -1,0 +1,501 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1990
+  Moe Ghoul, President of Vice
+
+That's all there is to it!

--- a/app/src/test/java/elite/intel/ai/ApiFactoryTest.java
+++ b/app/src/test/java/elite/intel/ai/ApiFactoryTest.java
@@ -1,0 +1,22 @@
+package elite.intel.ai;
+
+import elite.intel.ai.mouth.edge.EdgeTTSImpl;
+import elite.intel.ai.mouth.google.GoogleTTSImpl;
+import elite.intel.ai.mouth.kokoro.KokoroTTS;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ApiFactoryTest {
+    @Test
+    void cloudProviderSelectsTheMatchingMouth() {
+        assertSame(EdgeTTSImpl.getInstance(), ApiFactory.selectMouth(false, ProviderEnum.EDGE_TTS));
+        assertSame(GoogleTTSImpl.getInstance(), ApiFactory.selectMouth(false, ProviderEnum.GOOGLE_TTS));
+    }
+
+    @Test
+    void localAndUnrecognizedConfigurationsPreserveKokoroFallback() {
+        assertSame(KokoroTTS.getInstance(), ApiFactory.selectMouth(true, ProviderEnum.EDGE_TTS));
+        assertSame(KokoroTTS.getInstance(), ApiFactory.selectMouth(false, ProviderEnum.UNKNOWN));
+    }
+}

--- a/app/src/test/java/elite/intel/ai/KeyDetectorTest.java
+++ b/app/src/test/java/elite/intel/ai/KeyDetectorTest.java
@@ -1,0 +1,25 @@
+package elite.intel.ai;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KeyDetectorTest {
+    @Test
+    void exactEdgeSentinelSelectsEdgeOnlyForTts() {
+        assertEquals(ProviderEnum.EDGE_TTS, KeyDetector.detectProvider("edge://", "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("edge://", "LLM"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("EDGE://", "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider(" edge://", "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("edge:///", "TTS"));
+    }
+
+    @Test
+    void existingAndFallbackDetectionRemainUnchanged() {
+        assertEquals(ProviderEnum.GOOGLE_TTS,
+                KeyDetector.detectProvider("AIzaSy123456789012345678901234567890123", "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider(null, "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("", "TTS"));
+        assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("not-a-key", "TTS"));
+    }
+}

--- a/app/src/test/java/elite/intel/ai/brain/commons/AiResponseLanguagePolicyTest.java
+++ b/app/src/test/java/elite/intel/ai/brain/commons/AiResponseLanguagePolicyTest.java
@@ -1,0 +1,28 @@
+package elite.intel.ai.brain.commons;
+
+import elite.intel.i18n.Language;
+import elite.intel.session.SystemSession;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiResponseLanguagePolicyTest {
+    @Test
+    void edgeCloudTtsKeepsTheConfiguredCyrillicLanguage() {
+        SystemSession session = SystemSession.getInstance();
+        boolean previousLocal = session.useLocalTTS();
+        String previousKey = session.getTtsApiKey();
+        Language previousLanguage = session.getLanguage();
+        try {
+            session.setUseLocalTTS(false);
+            session.setTtsApiKey("edge://");
+            session.setLanguage(Language.UK);
+
+            assertEquals(Language.UK, AiResponseLanguagePolicy.resolveEffectiveAiResponseLanguage(session));
+        } finally {
+            session.setUseLocalTTS(previousLocal);
+            session.setTtsApiKey(previousKey);
+            session.setLanguage(previousLanguage);
+        }
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeAudioStreamAssemblerTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeAudioStreamAssemblerTest.java
@@ -1,0 +1,59 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EdgeAudioStreamAssemblerTest {
+    @Test
+    void parsesTextAndAssemblesAudioFramesInArrivalOrder() throws Exception {
+        EdgeAudioStreamAssembler assembler = new EdgeAudioStreamAssembler();
+
+        assertFalse(assembler.acceptText("Path:turn.start\r\nX-RequestId:abc\r\n\r\n{}"));
+        assembler.acceptBinary(frame("Path:audio\r\nContent-Type:audio/mpeg\r\n", new byte[]{1, 2}));
+        assembler.acceptBinary(frame("Path:audio\r\nContent-Type:audio/mpeg\r\n", new byte[]{3, 4}));
+        assembler.acceptBinary(frame("Path:audio\r\n", new byte[0]));
+        assertTrue(assembler.acceptText("Path:turn.end\r\n\r\n{}"));
+
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, assembler.audio());
+    }
+
+    @Test
+    void rejectsMalformedOrUnexpectedProtocolMessages() {
+        EdgeAudioStreamAssembler assembler = new EdgeAudioStreamAssembler();
+
+        assertThrows(EdgeProtocolException.class, () -> assembler.acceptText("no separator"));
+        assertThrows(EdgeProtocolException.class,
+                () -> assembler.acceptText("Path:unknown\r\n\r\n{}"));
+        assertThrows(EdgeProtocolException.class, () -> assembler.acceptBinary(new byte[]{0}));
+        assertThrows(EdgeProtocolException.class,
+                () -> assembler.acceptBinary(frame("Path:not-audio\r\n", new byte[]{1})));
+        assertThrows(EdgeProtocolException.class,
+                () -> assembler.acceptBinary(frame("Path:audio\r\nContent-Type:text/plain\r\n", new byte[]{1})));
+        assertThrows(EdgeProtocolException.class,
+                () -> assembler.acceptBinary(frame("Path:audio\r\nContent-Type:audio/mpeg\r\n", new byte[0])));
+    }
+
+    @Test
+    void binaryParserRejectsInvalidHeaderLengthsAndMissingPath() {
+        assertThrows(EdgeProtocolException.class,
+                () -> EdgeProtocolMessageParser.parseBinary(new byte[]{0, 10, 1, 2}));
+        assertThrows(EdgeProtocolException.class,
+                () -> EdgeProtocolMessageParser.parseBinary(frame("Content-Type:audio/mpeg\r\n", new byte[]{1})));
+    }
+
+    private static byte[] frame(String header, byte[] body) {
+        byte[] headers = header.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(2 + headers.length + body.length)
+                .putShort((short) headers.length)
+                .put(headers)
+                .put(body)
+                .array();
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeMp3DecoderTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeMp3DecoderTest.java
@@ -1,0 +1,77 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EdgeMp3DecoderTest {
+    private static final int INCOMPLETE_TRAILING_BYTES = 15;
+
+    // First several frames of Espressif's 24 kHz mono test sample, "Furious Freak" by Kevin MacLeod,
+    // CC BY 3.0: https://dl.espressif.com/dl/audio/ff-16b-1c-24000hz.mp3
+    private static final String SAMPLE = """
+            SUQzBAAAAAABR1RJVDIAAAAPAAADRnVyaW91cyBGcmVhawBUUEUxAAAADwAAA0tldmluIE1hY0xlb2QAVFhY
+            WAAAABMAAANUQ00AS2V2aW4gTWFjTGVvZABURU5DAAAAEgAAA2lUdW5lcyAxMi4zLjMuMTcAVFhYWAAA
+            AAkAAANUQlAAMTI3AFRDT04AAAAMAAADRWxlY3Ryb25pYwBURFJDAAAABgAAAzIwMTYAVFNTRQAAAA8A
+            AANMYXZmNTYuNDAuMTAxAAAAAAAAAAAAAAD/84TAAAAAAAAAAAAASW5mbwAAAA8AAB54AAttwAADBQgKDQ8S
+            FRcaHB8hJCYpLC4xMzY4Oj5AQ0VISkxPUVVXWlxeYWNmaWxucHN1eHp+gIKFh4qMj5KUl5mcnqGjpamr
+            rrCztbe6vcDCxcfJzM7S1NfZ297g4+bp6+3w8vX3+/0AAAAATGF2YzU2LjYwAAAAAAAAAAAAAAAAJAAA
+            AAAAAAALbcC2dNLpAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/80TEAA7a/VgECEc9WD//2k5kbTaGRlaT
+            X/9N5GQWkwGRiTaGD6f2vI2m0MjK0mv/6bX2k1//Ta+0mv//8ViM0dKysMMLA6dKApAEDW5PdP93f35
+            zGXz9VkP68Q0jkMT/80TEFxHIAe1GCEYBmzC6TcnH3MwUHspJx7L//PQ9lHIejfJ///HYa46Tz///z+
+            9v9+9+f18hZG+bmzH51QEB0GjGMrexitxNvuX8cvdwiQIghI73v3T4WiIBgYsDcW7/80TEIhhaqgABS
+            xgB5pXcOcIkCJ5nmHAxbue9EJFDuxZe9/dCMkQvpm7ua5fCROwj0Qp+iIkum5u7nu9MEiBAPs4BwPnHA
+            GYYAIBEiv9y3fZaNF/9tSxTME5/8w4hkjH/80TEExYxJnABmZAAani4C4aBYSOUSHiCZJoGocECNxMhB
+            X45ZEzczNw+gjIi47RkP2zRBjMnjtI/58uHwgCrleiGAfeIkV/1Bg/hA9t/6OBPrgQrxJH4isCsba215
+            p3/80TEDRWpbnS52XgBixkKFmoIuFLYTVV3OzYiWjHa8N91R5QQOJihvMQd4C5C30diEQJVl5w+coSCU
+            de3Pa/wrbXb23ff/1qidfD6/+v26vxuv8DNjeUGYRKOywsCCAj/80TECRRRUmwYy8rRrjwC1bDtLQB/
+            oXEIHAEyUHTE8ARigS3MAOE23LaYT4UwzmEKCEtaPK8xyNCqIuxhxpUEyb7cg957/FTikF/GnwiT3GD3
+            pd3m1Q4zd7iP6gxcRAD/80TEChPhMmAQ1g6wqI5spJUBlyZAdFUguXJo0YlxbknJVtG2sewm5+PLWRmg
+            aRFQZFCT/xwd+0YmG1zFbMgg2BhLoFwXZglPFSEYu/HXxzvetSPo+0RHDULo7QwhXUP/80TEDRQRAlgI
+            3lqWJbHljALaCg0hWcGTFNbAHZFKiOB/2egjZc+bK5dXa+5dPSoep1YdrMwy1HiIZsODWHtbLgUcZw1N
+            MCX00E1FBaJG+9UEydok+DkThlpJtpsz1EX/80TEDxLhSoTYekznzKsGUKt8uATYZESQHy/3l0NgWIz+
+            lRLlIydjLHGYK74YQkmWhBg8L8xVk7YgimYYTIEAm9xya7GDw/zA9YQgFFN8IMweGOMrN7Ezgwqqsoh
+            Qsqv/80TEFhRxRqm4Gl4XMiKUmRJBIDveyntGTokSti9iU+vvPnypSEEXBtCQBYnOEdw8WJ5oHYM1lkw
+            Oee+ZSwRpWFhK/8ToU2MNGXLO+sc75hH8Ol8qIKywnsIEV2LicOH/80TEFxI5fow4esUSmoqQq4j56v
+            CMtU3wjdIi27yWA08xZOzgKkL4I76UNH/Y9EaLsbL50efLitJXDUuK9lKAT4XMa4wEZHBKBgtandOCHs
+            lV8ts1KYvppJYZ6ElhwIH/80TEIRJhSny4w88E3aYvDQSeLtm3HCdVs3DwjVzxKaprzviWLdAw0fMOvH
+            w7gmZSS2UvsrosKDdMIBLQWGQdJ8Ti5nofmWx1RR85qgFSkxcqoCYCnSGqmySBBKkd2zX/80TEKhGBHn
+            QQw9Ug9sCAep+QQ6QZ1TwNuySnulzKgZP3BryqNxe3JRaBc7tKpJ6MFAx6/slfBp8ulE5R5SwqhhPxxS
+            sua7bP4GhA/VZMsli+HWl+EfZDO/XfdU1jtq7/80TENxJhIoAZWMAA0ef6sT//uWawqXK/f7Jc+/9Nyg
+            CAdHsHB8NR6AA9AMVbIsaeyFiHSd9Oarsc6MzAIDQMxrJ0CJwNGra4ixv/zH0QgSzU4eoCgVqUy/8dvW
+            iTILX/80TEQBlRDn3/mcAAJ3TTFyxrf//6wyZj9VaOUpUq5kMpuRr9fT+/mrb/7/scn/f/YuoL0ByHVH
+            euFDpvX5bTnk7+//7xc3vqOtfzw7wEFR8+bjMPXof/eexZeizfn63/80TELRJIHgwBzxgBblf6PklS/0
+            th+85jFF7/9Dt+Yp+KBgKO5Y1VrdVYTFniqlFnnYeHsc2YMJnRz9ipUUeqDR5gfxj57x5sJPJDKq587
+            FQkkYPErYlh0JFjYVGPeLr/80TENhDICggBSRgA3j1tSl9JRkYsYSKhV6qL9av46KBB38/84Js3IfXP0
+            mCZULU9oXwBqbA1497d4WzC18LFwucf/cUKHLhaYH7ix9Ol+N8nRcYsZ4g/Svt1xYyAHif/80TERSC7K
+            iABmqAAx0A=
+            """;
+
+    @Test
+    void decodesUpstreamFormatToLittleEndianPcm16() throws Exception {
+        byte[] pcm = new EdgeMp3Decoder().decode(completeSample());
+
+        assertTrue(pcm.length >= 2_304);
+        assertEquals(0, pcm.length % 2);
+    }
+
+    @Test
+    void rejectsEmptyAndMalformedAudio() {
+        EdgeMp3Decoder decoder = new EdgeMp3Decoder();
+        assertThrows(IOException.class, () -> decoder.decode(new byte[0]));
+        assertThrows(IOException.class, () -> decoder.decode(new byte[]{1, 2, 3, 4}));
+        byte[] sample = completeSample();
+        assertThrows(IOException.class, () -> decoder.decode(Arrays.copyOf(sample, sample.length - 37)));
+    }
+
+    private static byte[] completeSample() {
+        byte[] sample = Base64.getMimeDecoder().decode(SAMPLE);
+        return Arrays.copyOf(sample, sample.length - INCOMPLETE_TRAILING_BYTES);
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeProtocolAuthTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeProtocolAuthTest.java
@@ -1,0 +1,59 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EdgeProtocolAuthTest {
+    private static final Instant NOW = Instant.parse("2024-01-02T03:04:05Z");
+
+    @Test
+    void generatesStableGecAndFreshMuidCookiePerRequest() {
+        byte[] muid = new byte[16];
+        for (int i = 0; i < muid.length; i++) {
+            muid[i] = (byte) i;
+        }
+        AtomicInteger sequence = new AtomicInteger();
+        EdgeProtocolAuth auth = new EdgeProtocolAuth(Clock.fixed(NOW, ZoneOffset.UTC), () -> {
+            byte[] next = muid.clone();
+            next[0] = (byte) sequence.getAndIncrement();
+            return next;
+        });
+
+        assertEquals("BD721EDF522D70BE4575BAABDC730E8B6AE84F3A5FB57B5B31FE70FC89384262",
+                auth.secMsGec());
+        assertEquals("muid=000102030405060708090A0B0C0D0E0F;",
+                auth.withMuid(Map.of("Accept", "*/*")).get("Cookie"));
+        assertEquals("muid=010102030405060708090A0B0C0D0E0F;",
+                auth.withMuid(Map.of("Accept", "*/*")).get("Cookie"));
+    }
+
+    @Test
+    void serverDateAdjustsTheTokenWindowAndBadDatesFailClearly() throws Exception {
+        EdgeProtocolAuth auth = new EdgeProtocolAuth(Clock.fixed(NOW, ZoneOffset.UTC), () -> new byte[16]);
+        String before = auth.secMsGec();
+
+        auth.adjustToServerDate("Tue, 2 Jan 2024 03:10:05 GMT");
+
+        assertNotEquals(before, auth.secMsGec());
+        assertThrows(EdgeProtocolException.class, () -> auth.adjustToServerDate(null));
+        assertThrows(EdgeProtocolException.class, () -> auth.adjustToServerDate("not a date"));
+    }
+
+    @Test
+    void rejectsInvalidMuidSourcesAndDuplicateCookies() {
+        EdgeProtocolAuth invalid = new EdgeProtocolAuth(Clock.fixed(NOW, ZoneOffset.UTC), () -> new byte[15]);
+        assertThrows(IllegalStateException.class, () -> invalid.withMuid(Map.of()));
+
+        EdgeProtocolAuth valid = new EdgeProtocolAuth(Clock.fixed(NOW, ZoneOffset.UTC), () -> new byte[16]);
+        assertThrows(IllegalArgumentException.class, () -> valid.withMuid(Map.of("Cookie", "existing")));
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeReadAloudClientTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeReadAloudClientTest.java
@@ -1,0 +1,389 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EdgeReadAloudClientTest {
+    private static final Instant NOW = Instant.parse("2024-01-02T03:04:05Z");
+    private static final String VOICES = """
+            [{"Name":"Full Emma","ShortName":"en-US-EmmaMultilingualNeural",
+              "Gender":"Female","Locale":"en-US",
+              "SuggestedCodec":"audio-24khz-48kbitrate-mono-mp3"}]
+            """;
+
+    @Test
+    void voiceListUsesCurrentHeadersAndRetriesOne403AfterClockCorrection() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        http.responses.add(response(403, "", Map.of("Date", List.of("Tue, 2 Jan 2024 03:10:05 GMT"))));
+        http.responses.add(response(200, VOICES, Map.of()));
+        EdgeProtocolAuth auth = authWithDistinctMuids();
+        EdgeReadAloudClient client = client(http, auth);
+
+        List<EdgeVoice> voices = client.listVoices();
+
+        assertEquals("en-US-EmmaMultilingualNeural", voices.getFirst().shortName());
+        assertEquals(2, http.requests.size());
+        HttpRequest first = http.requests.getFirst();
+        HttpRequest second = http.requests.get(1);
+        assertTrue(first.uri().toString().contains("trustedclienttoken="
+                + EdgeProtocolConstants.TRUSTED_CLIENT_TOKEN));
+        assertTrue(first.uri().toString().contains("Sec-MS-GEC-Version=1-143.0.3650.75"));
+        assertNotEquals(query(first.uri(), "Sec-MS-GEC"), query(second.uri(), "Sec-MS-GEC"));
+        assertNotEquals(first.headers().firstValue("Cookie"), second.headers().firstValue("Cookie"));
+        assertEquals("*/*", first.headers().firstValue("Accept").orElseThrow());
+        assertEquals(Duration.ofMillis(100), first.timeout().orElseThrow());
+        assertTrue(first.headers().firstValue("User-Agent").orElseThrow().contains("Edg/143.0.0.0"));
+        assertTrue(first.headers().firstValue("Sec-CH-UA").orElseThrow().contains("Chromium\";v=\"143"));
+    }
+
+    @Test
+    void synthesisSendsFramedMessagesAndAssemblesAudioInOrder() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        http.webSocketPlans.add(WebSocketPlan.success(new byte[]{1, 2}, new byte[]{3, 4}));
+        EdgeReadAloudClient client = client(http, authWithDistinctMuids());
+
+        byte[] audio = client.synthesize(request("request-one"));
+
+        assertArrayEquals(new byte[]{1, 2, 3, 4}, audio);
+        StubWebSocketBuilder builder = http.builders.getFirst();
+        assertTrue(builder.uri.toString().contains("ConnectionId="));
+        assertTrue(builder.uri.toString().contains("TrustedClientToken="
+                + EdgeProtocolConstants.TRUSTED_CLIENT_TOKEN));
+        assertEquals("no-cache", builder.headers.get("Cache-Control"));
+        assertTrue(builder.headers.get("Cookie").startsWith("muid="));
+        assertEquals(2, builder.socket.sentText.size());
+        assertTrue(builder.socket.sentText.getFirst().contains("Path:speech.config"));
+        assertTrue(builder.socket.sentText.getFirst().contains(
+                "\"sentenceBoundaryEnabled\":\"true\""));
+        assertTrue(builder.socket.sentText.get(1).contains("Path:ssml\r\n\r\n"));
+        assertTrue(builder.socket.sentText.get(1).contains("X-Timestamp:")
+                && builder.socket.sentText.get(1).contains(")Z\r\n"));
+        assertTrue(builder.socket.aborted);
+    }
+
+    @Test
+    void websocket403RetriesOnceAndMalformedOrSilentResponsesFailCleanly() throws Exception {
+        StubHttpClient retrying = new StubHttpClient();
+        retrying.webSocketPlans.add(WebSocketPlan.handshake403());
+        retrying.webSocketPlans.add(WebSocketPlan.success(new byte[]{7}));
+        assertArrayEquals(new byte[]{7}, client(retrying, authWithDistinctMuids()).synthesize(request("retry")));
+        assertEquals(2, retrying.builders.size());
+        assertNotEquals(query(retrying.builders.getFirst().uri, "Sec-MS-GEC"),
+                query(retrying.builders.get(1).uri, "Sec-MS-GEC"));
+
+        StubHttpClient malformed = new StubHttpClient();
+        malformed.webSocketPlans.add(WebSocketPlan.malformed());
+        EdgeProtocolException badFrame = assertThrows(EdgeProtocolException.class,
+                () -> client(malformed, authWithDistinctMuids()).synthesize(request("bad-frame")));
+        assertTrue(badFrame.getMessage().contains("header length"));
+
+        StubHttpClient silent = new StubHttpClient();
+        silent.webSocketPlans.add(WebSocketPlan.silent());
+        EdgeProtocolException timeout = assertThrows(EdgeProtocolException.class,
+                () -> client(silent, authWithDistinctMuids()).synthesize(request("silent")));
+        assertTrue(timeout.getMessage().contains("Timed out receiving"));
+        assertTrue(silent.builders.getFirst().socket.aborted);
+    }
+
+    @Test
+    void cancellationAbortsAnInProgressConnectionPromptly() throws Exception {
+        StubHttpClient http = new StubHttpClient();
+        WebSocketPlan connecting = WebSocketPlan.connecting();
+        http.webSocketPlans.add(connecting);
+        EdgeReadAloudClient client = client(http, authWithDistinctMuids());
+        CompletableFuture<Throwable> outcome = CompletableFuture.supplyAsync(() -> {
+            try {
+                client.synthesize(request("cancel-me"));
+                return new AssertionError("synthesis unexpectedly succeeded");
+            } catch (Throwable failure) {
+                return failure;
+            }
+        });
+
+        assertTrue(connecting.started.get(1, TimeUnit.SECONDS));
+        client.cancel("cancel-me");
+
+        Throwable failure = outcome.get(1, TimeUnit.SECONDS);
+        assertTrue(failure instanceof EdgeProtocolException);
+        assertTrue(failure.getMessage().contains("cancelled"));
+        assertTrue(connecting.connection.isCancelled());
+    }
+
+    @Test
+    void connectionTimeoutCancelsThePendingHandshake() {
+        StubHttpClient http = new StubHttpClient();
+        WebSocketPlan connecting = WebSocketPlan.connecting();
+        http.webSocketPlans.add(connecting);
+
+        EdgeProtocolException failure = assertThrows(EdgeProtocolException.class,
+                () -> client(http, authWithDistinctMuids()).synthesize(request("connect-timeout")));
+
+        assertTrue(failure.getMessage().contains("Timed out connecting"));
+        assertTrue(connecting.connection.isCancelled());
+    }
+
+    private static EdgeReadAloudClient client(StubHttpClient http, EdgeProtocolAuth auth) {
+        return new EdgeReadAloudClient(
+                http, auth, Duration.ofMillis(100), Duration.ofMillis(100), Duration.ofMillis(30));
+    }
+
+    private static EdgeProtocolAuth authWithDistinctMuids() {
+        AtomicInteger sequence = new AtomicInteger();
+        return new EdgeProtocolAuth(Clock.fixed(NOW, ZoneOffset.UTC), () -> {
+            byte[] muid = new byte[16];
+            muid[15] = (byte) sequence.getAndIncrement();
+            return muid;
+        });
+    }
+
+    private static EdgeSynthesisRequest request(String id) {
+        return new EdgeSynthesisRequest(
+                id,
+                "Elite Intel test.",
+                new EdgeVoice(null, "en-US-EmmaMultilingualNeural", "Female", "en-US",
+                        EdgeProtocolConstants.OUTPUT_FORMAT),
+                "+0%", "+0%", "+0Hz");
+    }
+
+    private static String query(URI uri, String name) {
+        for (String pair : uri.getRawQuery().split("&")) {
+            int equals = pair.indexOf('=');
+            if (equals > 0 && pair.substring(0, equals).equals(name)) {
+                return pair.substring(equals + 1);
+            }
+        }
+        throw new AssertionError("Missing query parameter " + name);
+    }
+
+    private static HttpResponse<String> response(int status, String body, Map<String, List<String>> headers) {
+        return new StubResponse<>(status, body, HttpHeaders.of(headers, (name, value) -> true), null);
+    }
+
+    private static byte[] frame(String headers, byte[] body) {
+        byte[] encoded = headers.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(2 + encoded.length + body.length)
+                .putShort((short) encoded.length)
+                .put(encoded)
+                .put(body)
+                .array();
+    }
+
+    private static final class StubHttpClient extends HttpClient {
+        private final Queue<HttpResponse<String>> responses = new ArrayDeque<>();
+        private final Queue<WebSocketPlan> webSocketPlans = new ArrayDeque<>();
+        private final List<HttpRequest> requests = new ArrayList<>();
+        private final List<StubWebSocketBuilder> builders = new ArrayList<>();
+
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler)
+                throws IOException {
+            requests.add(request);
+            HttpResponse<String> response = responses.poll();
+            if (response == null) {
+                throw new IOException("No stub HTTP response");
+            }
+            HttpResponse.ResponseInfo responseInfo = new HttpResponse.ResponseInfo() {
+                @Override public int statusCode() { return response.statusCode(); }
+                @Override public HttpHeaders headers() { return response.headers(); }
+                @Override public Version version() { return Version.HTTP_2; }
+            };
+            HttpResponse.BodySubscriber<T> subscriber = handler.apply(responseInfo);
+            subscriber.onSubscribe(new java.util.concurrent.Flow.Subscription() {
+                @Override public void request(long count) { }
+                @Override public void cancel() { }
+            });
+            if (!response.body().isEmpty()) {
+                subscriber.onNext(List.of(ByteBuffer.wrap(response.body().getBytes(StandardCharsets.UTF_8))));
+            }
+            subscriber.onComplete();
+            T body = subscriber.getBody().toCompletableFuture().join();
+            return new StubResponse<>(response.statusCode(), body, response.headers(), request);
+        }
+
+        @Override
+        public WebSocket.Builder newWebSocketBuilder() {
+            StubWebSocketBuilder builder = new StubWebSocketBuilder(webSocketPlans.remove());
+            builders.add(builder);
+            return builder;
+        }
+
+        @Override public Optional<CookieHandler> cookieHandler() { return Optional.empty(); }
+        @Override public Optional<Duration> connectTimeout() { return Optional.empty(); }
+        @Override public Redirect followRedirects() { return Redirect.NEVER; }
+        @Override public Optional<ProxySelector> proxy() { return Optional.empty(); }
+        @Override public SSLContext sslContext() { return null; }
+        @Override public SSLParameters sslParameters() { return new SSLParameters(); }
+        @Override public Optional<Authenticator> authenticator() { return Optional.empty(); }
+        @Override public Version version() { return Version.HTTP_2; }
+        @Override public Optional<Executor> executor() { return Optional.empty(); }
+        @Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> handler) { throw new UnsupportedOperationException(); }
+        @Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> handler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) { throw new UnsupportedOperationException(); }
+    }
+
+    private static final class StubWebSocketBuilder implements WebSocket.Builder {
+        private final WebSocketPlan plan;
+        private final Map<String, String> headers = new java.util.LinkedHashMap<>();
+        private URI uri;
+        private StubWebSocket socket;
+
+        private StubWebSocketBuilder(WebSocketPlan plan) {
+            this.plan = plan;
+        }
+
+        @Override
+        public WebSocket.Builder header(String name, String value) {
+            headers.put(name, value);
+            return this;
+        }
+
+        @Override public WebSocket.Builder connectTimeout(Duration timeout) { return this; }
+        @Override public WebSocket.Builder subprotocols(String mostPreferred, String... lesserPreferred) {
+            return this;
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> buildAsync(URI uri, WebSocket.Listener listener) {
+            this.uri = uri;
+            return plan.connect(uri, listener, this);
+        }
+    }
+
+    private static final class WebSocketPlan {
+        private enum Mode { SUCCESS, HANDSHAKE_403, MALFORMED, SILENT, CONNECTING }
+
+        private final Mode mode;
+        private final byte[][] audio;
+        private final CompletableFuture<Boolean> started = new CompletableFuture<>();
+        private final CompletableFuture<WebSocket> connection = new CompletableFuture<>();
+
+        private WebSocketPlan(Mode mode, byte[][] audio) {
+            this.mode = mode;
+            this.audio = audio;
+        }
+
+        static WebSocketPlan success(byte[]... audio) { return new WebSocketPlan(Mode.SUCCESS, audio); }
+        static WebSocketPlan handshake403() { return new WebSocketPlan(Mode.HANDSHAKE_403, new byte[0][]); }
+        static WebSocketPlan malformed() { return new WebSocketPlan(Mode.MALFORMED, new byte[0][]); }
+        static WebSocketPlan silent() { return new WebSocketPlan(Mode.SILENT, new byte[0][]); }
+        static WebSocketPlan connecting() { return new WebSocketPlan(Mode.CONNECTING, new byte[0][]); }
+
+        private CompletableFuture<WebSocket> connect(
+                URI uri, WebSocket.Listener listener, StubWebSocketBuilder builder) {
+            started.complete(true);
+            if (mode == Mode.CONNECTING) {
+                return connection;
+            }
+            if (mode == Mode.HANDSHAKE_403) {
+                HttpResponse<Void> response = new StubResponse<>(403, null, HttpHeaders.of(
+                        Map.of("Date", List.of("Tue, 2 Jan 2024 03:10:05 GMT")), (name, value) -> true), null);
+                return CompletableFuture.failedFuture(new WebSocketHandshakeException(response));
+            }
+            StubWebSocket socket = new StubWebSocket(listener, this);
+            builder.socket = socket;
+            listener.onOpen(socket);
+            return CompletableFuture.completedFuture(socket);
+        }
+    }
+
+    private static final class StubWebSocket implements WebSocket {
+        private final WebSocket.Listener listener;
+        private final WebSocketPlan plan;
+        private final List<String> sentText = new ArrayList<>();
+        private boolean aborted;
+
+        private StubWebSocket(WebSocket.Listener listener, WebSocketPlan plan) {
+            this.listener = listener;
+            this.plan = plan;
+        }
+
+        @Override
+        public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+            sentText.add(data.toString());
+            if (sentText.size() == 2) {
+                if (plan.mode == WebSocketPlan.Mode.MALFORMED) {
+                    listener.onBinary(this, ByteBuffer.wrap(new byte[]{0}), true);
+                } else if (plan.mode == WebSocketPlan.Mode.SUCCESS) {
+                    listener.onText(this, "Path:response\r\n\r\n{}", true);
+                    listener.onText(this, "Path:turn.start\r\n\r\n{}", true);
+                    listener.onText(this, "Path:audio.metadata\r\n\r\n{}", true);
+                    for (byte[] audio : plan.audio) {
+                        listener.onBinary(this, ByteBuffer.wrap(frame(
+                                "Path:audio\r\nContent-Type:audio/mpeg\r\n", audio)), true);
+                    }
+                    listener.onBinary(this, ByteBuffer.wrap(frame("Path:audio\r\n", new byte[0])), true);
+                    listener.onText(this, "Path:turn.end\r\n\r\n{}", true);
+                }
+            }
+            return CompletableFuture.completedFuture(this);
+        }
+
+        @Override public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) {
+            return CompletableFuture.completedFuture(this);
+        }
+        @Override public CompletableFuture<WebSocket> sendPing(ByteBuffer message) {
+            return CompletableFuture.completedFuture(this);
+        }
+        @Override public CompletableFuture<WebSocket> sendPong(ByteBuffer message) {
+            return CompletableFuture.completedFuture(this);
+        }
+        @Override public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) {
+            return CompletableFuture.completedFuture(this);
+        }
+        @Override public void request(long n) { }
+        @Override public String getSubprotocol() { return ""; }
+        @Override public boolean isOutputClosed() { return aborted; }
+        @Override public boolean isInputClosed() { return aborted; }
+        @Override public void abort() { aborted = true; }
+    }
+
+    private record StubResponse<T>(
+            int statusCode,
+            T body,
+            HttpHeaders headers,
+            HttpRequest request
+    ) implements HttpResponse<T> {
+        @Override public Optional<HttpResponse<T>> previousResponse() { return Optional.empty(); }
+        @Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+        @Override public URI uri() { return request == null ? URI.create("https://example.test") : request.uri(); }
+        @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_2; }
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeSentenceSplitterTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeSentenceSplitterTest.java
@@ -1,0 +1,55 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EdgeSentenceSplitterTest {
+    @Test
+    void recognizesAsciiUnicodeQuotesAndNewlinesButNotCommasOrDecimals() {
+        assertEquals(List.of("First sentence.", "Second?", "Third!"),
+                EdgeSentenceSplitter.split("First sentence. Second? Third!"));
+        assertEquals(List.of("Вітаю!", "Як справи？", "Добре…。", "Гаразд！"),
+                EdgeSentenceSplitter.split("Вітаю! Як справи？ Добре…。 Гаразд！"));
+        assertEquals(List.of("He said \"go.\"", "Then left."),
+                EdgeSentenceSplitter.split("He said \"go.\" Then left."));
+        assertEquals(List.of("Value 3.14, still one sentence."),
+                EdgeSentenceSplitter.split("Value 3.14, still one sentence."));
+        assertEquals(List.of("line one", "line two"), EdgeSentenceSplitter.split("line one\nline two"));
+    }
+
+    @Test
+    void boundsEscapedUtf8WithoutBreakingCodePoints() {
+        String token = "😀<& Привіт ";
+        String text = token.repeat(600).strip();
+        List<String> parts = EdgeSentenceSplitter.split(text);
+
+        assertTrue(parts.size() > 1);
+        assertTrue(parts.stream().allMatch(part ->
+                EdgeSsml.escape(part).getBytes(StandardCharsets.UTF_8).length
+                        <= EdgeSentenceSplitter.MAX_ESCAPED_TEXT_BYTES));
+        assertFalse(parts.stream().anyMatch(part -> Character.isLowSurrogate(part.charAt(0))));
+        assertEquals(text.replaceAll("\\s+", " "), String.join(" ", parts).replaceAll("\\s+", " "));
+    }
+
+    @Test
+    void usesTheFull4096ByteLimitAndKeepsEscapedEntitiesWhole() {
+        String ascii = "a".repeat(4_097);
+        List<String> asciiParts = EdgeSentenceSplitter.split(ascii);
+        assertEquals(4_096, asciiParts.getFirst().getBytes(StandardCharsets.UTF_8).length);
+        assertEquals(ascii, String.join("", asciiParts));
+
+        String entitiesAndEmoji = "<&😀>".repeat(1_000);
+        List<String> escapedParts = EdgeSentenceSplitter.split(entitiesAndEmoji);
+        assertEquals(entitiesAndEmoji, String.join("", escapedParts));
+        assertTrue(escapedParts.stream().allMatch(part ->
+                EdgeSsml.escape(part).getBytes(StandardCharsets.UTF_8).length <= 4_096));
+        assertTrue(escapedParts.stream().map(EdgeSsml::escape)
+                .noneMatch(part -> part.matches("(?s).*&(?:amp|lt|gt|quot|apos)?$")));
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeSsmlTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeSsmlTest.java
@@ -1,0 +1,50 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EdgeSsmlTest {
+    @Test
+    void escapesXmlAndUnsupportedControlsWithoutDamagingUnicode() {
+        String escaped = EdgeSsml.escape("A&B <tag> \"quote\" 'single'\u0001 Привіт 😀");
+
+        assertEquals("A&amp;B &lt;tag&gt; &quot;quote&quot; &apos;single&apos;  Привіт 😀", escaped);
+        assertFalse(escaped.contains("\u0001"));
+    }
+
+    @Test
+    void translatesApplicationRateVolumeAndPitchToEdgeProsody() {
+        assertEquals("+25%", EdgeSsml.rate(0.25f));
+        assertEquals("-25%", EdgeSsml.rate(-0.25f));
+        assertEquals("+0%", EdgeSsml.volume(100));
+        assertEquals("-75%", EdgeSsml.volume(25));
+        assertEquals("-100%", EdgeSsml.volume(-1));
+        assertEquals("+0Hz", EdgeSsml.pitch(0));
+        assertEquals("-7Hz", EdgeSsml.pitch(-7));
+    }
+
+    @Test
+    void buildsProtocolVoiceAndFramedSsmlMessages() {
+        String voice = EdgeSsml.protocolVoiceName("en-US-EmmaMultilingualNeural");
+        String ssml = EdgeSsml.build("Use <this>", voice, "+10%", "+0%", "+0Hz");
+
+        assertEquals("Microsoft Server Speech Text to Speech Voice (en-US, EmmaMultilingualNeural)", voice);
+        assertTrue(ssml.contains("Use &lt;this&gt;"));
+        assertTrue(ssml.contains("rate='+10%'"));
+        assertTrue(EdgeSsml.speechConfig(Instant.EPOCH).contains(
+                "audio-24khz-48kbitrate-mono-mp3"));
+        assertTrue(EdgeSsml.speechConfig(Instant.EPOCH).contains(
+                "\"sentenceBoundaryEnabled\":\"true\""));
+        String message = EdgeSsml.ssmlMessage(ssml, Instant.EPOCH);
+        assertTrue(message.contains("X-Timestamp:Thu Jan 01 1970 00:00:00 "
+                + "GMT+0000 (Coordinated Universal Time)Z\r\n"));
+        assertTrue(message.contains("Path:ssml\r\n\r\n" + ssml));
+        assertThrows(IllegalArgumentException.class, () -> EdgeSsml.protocolVoiceName("bad"));
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeTTSImplTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeTTSImplTest.java
@@ -1,0 +1,493 @@
+package elite.intel.ai.mouth.edge;
+
+import com.google.common.eventbus.Subscribe;
+import elite.intel.ai.mouth.subscribers.events.AiVoxResponseEvent;
+import elite.intel.ai.mouth.subscribers.events.TTSInterruptEvent;
+import elite.intel.ai.mouth.subscribers.events.VocalisationRequestEvent;
+import elite.intel.ai.mouth.subscribers.events.VocalisationSuccessfulEvent;
+import elite.intel.eventbus.GameEventBus;
+import elite.intel.i18n.Language;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class EdgeTTSImplTest {
+    private final List<EdgeTTSImpl> mouths = new ArrayList<>();
+
+    @AfterEach
+    void stopMouths() {
+        mouths.forEach(EdgeTTSImpl::stop);
+    }
+
+    @Test
+    void synthesizesAheadWhilePlayingInOrderAndSettlesOnce() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        output.blockPlayback();
+        EdgeTTSImpl mouth = mouth(client, output, 0.25f, 50);
+        SuccessRecorder successes = new SuccessRecorder();
+        GameEventBus.register(successes);
+        try {
+            CompletableFuture<Void> first = new CompletableFuture<>();
+            CompletableFuture<Void> second = new CompletableFuture<>();
+            AtomicInteger firstCompletions = completionCount(first);
+            AtomicInteger secondCompletions = completionCount(second);
+            mouth.start();
+
+            mouth.onVoiceProcessEvent(event("first", "one", first));
+            mouth.onVoiceProcessEvent(event("second", "two", second));
+
+            assertTrue(output.playStarted.await(2, TimeUnit.SECONDS));
+            assertTrue(client.twoSyntheses.await(2, TimeUnit.SECONDS),
+                    "the synthesis worker should prepare sentence two while sentence one plays");
+            assertFalse(first.isDone());
+            output.releasePlayback();
+            await(first);
+            await(second);
+
+            assertEquals(List.of("One", "Two"), client.requests.stream().map(EdgeSynthesisRequest::text).toList());
+            assertEquals(List.of("+25%", "+25%"), client.requests.stream().map(EdgeSynthesisRequest::rate).toList());
+            assertEquals(List.of("+0%", "+0%"), client.requests.stream().map(EdgeSynthesisRequest::volume).toList());
+            assertEquals(2, output.played.size());
+            assertEquals(1, firstCompletions.get());
+            assertEquals(1, secondCompletions.get());
+            assertEquals(2, successes.count.get());
+
+            // Sample 160 is outside the 6 ms fade. It proves decoded PCM gets application volume locally.
+            assertEquals(('O' * 100) / 2, sample(output.played.getFirst(), 160));
+            assertEquals(('T' * 100) / 2, sample(output.played.get(1), 160));
+        } finally {
+            GameEventBus.unregister(successes);
+        }
+    }
+
+    @Test
+    void boundsTheActualPostPreprocessingTextSentToEdge() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("expanded-text", "present ".repeat(600), completion));
+
+        await(completion);
+        assertTrue(client.requests.size() > 1);
+        assertTrue(client.requests.stream().noneMatch(request -> request.text().contains("present")));
+        assertTrue(client.requests.stream().allMatch(request -> EdgeSsml.escape(request.text())
+                .getBytes(StandardCharsets.UTF_8).length <= EdgeSentenceSplitter.MAX_ESCAPED_TEXT_BYTES));
+    }
+
+    @Test
+    void synthesisAndPlaybackFailuresCompleteExceptionallyWithoutKillingWorkers() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+
+        client.failText = "network";
+        CompletableFuture<Void> network = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("network-id", "network", network));
+        assertInstanceOf(IOException.class, awaitFailure(network));
+
+        output.failNext.set(true);
+        CompletableFuture<Void> device = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("device-id", "device", device));
+        assertInstanceOf(IOException.class, awaitFailure(device));
+
+        CompletableFuture<Void> recovery = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("recovery-id", "recovery", recovery));
+        await(recovery);
+        assertFalse(mouth.workersStopped());
+    }
+
+    @Test
+    void voiceEnumerationFailureUsesFallbackWithoutRetryingEverySentence() throws Exception {
+        FakeClient client = new FakeClient();
+        client.failVoiceList = true;
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+        CompletableFuture<Void> first = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("fallback", "one. two.", first));
+
+        await(first);
+        assertEquals(1, client.voiceListAttempts.get());
+        assertEquals(List.of(
+                        EdgeVoices.DEFAULT_FEMALE.defaultShortName(),
+                        EdgeVoices.DEFAULT_FEMALE.defaultShortName()),
+                client.requests.stream().map(request -> request.voice().shortName()).toList());
+
+        mouth.stop();
+        mouth.start();
+        CompletableFuture<Void> afterRestart = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("fallback-restart", "three", afterRestart));
+        await(afterRestart);
+        assertEquals(2, client.voiceListAttempts.get(), "a new service run may retry enumeration once");
+    }
+
+    @Test
+    void interruptionDuringDecodeDoesNotQueueStalePcmOrLeakANetworkCancellation() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        CountDownLatch decoding = new CountDownLatch(1);
+        CountDownLatch releaseDecode = new CountDownLatch(1);
+        EdgeAudioDecoder decoder = compressed -> {
+            decoding.countDown();
+            try {
+                releaseDecode.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("decode interrupted", e);
+            }
+            return pcm((char) compressed[0]);
+        };
+        EdgeTTSImpl mouth = mouth(client, output, decoder, 0f, 100);
+        mouth.start();
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("decode", "decode", completion));
+        assertTrue(decoding.await(2, TimeUnit.SECONDS));
+        mouth.shutUp(new TTSInterruptEvent("decode"));
+        releaseDecode.countDown();
+
+        await(completion);
+        awaitCondition(() -> client.requests.size() == 1);
+        assertTrue(client.cancelled.isEmpty(), "the completed network phase must not retain a cancellation marker");
+        assertTrue(output.played.isEmpty());
+    }
+
+    @Test
+    void middleSynthesisFailureStopsAlreadyPlayingAudioAndDropsRemainingSentences() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        output.blockPlayback();
+        client.failText = "Two.";
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("middle-failure", "one. two. three.", completion));
+
+        assertTrue(output.playStarted.await(2, TimeUnit.SECONDS));
+        assertInstanceOf(IOException.class, awaitFailure(completion));
+        awaitCondition(output.interrupted::get);
+        assertEquals(List.of("One.", "two."),
+                client.requests.stream().map(EdgeSynthesisRequest::text).toList());
+        assertEquals(1, output.played.size());
+    }
+
+    @Test
+    void targetedInterruptionCancelsOnlyTheMatchingRequest() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        client.blockRequest("first");
+        mouth.start();
+        CompletableFuture<Void> first = new CompletableFuture<>();
+        CompletableFuture<Void> second = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("first", "old", first));
+        assertTrue(client.blockedSynthesis.await(2, TimeUnit.SECONDS));
+        mouth.onVoiceProcessEvent(event("second", "new", second));
+        mouth.shutUp(new TTSInterruptEvent("first"));
+
+        await(first);
+        await(second);
+        assertEquals(List.of("first"), client.cancelled);
+        assertEquals(1, output.played.size());
+        assertEquals('N' * 100, sample(output.played.getFirst(), 160));
+    }
+
+    @Test
+    void globalInterruptionFencesOldWorkAndAllowsNewSpeech() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        client.blockRequest("active-old");
+        mouth.start();
+        CompletableFuture<Void> activeOld = new CompletableFuture<>();
+        CompletableFuture<Void> queuedOld = new CompletableFuture<>();
+
+        mouth.onVoiceProcessEvent(event("active-old", "active old", activeOld));
+        assertTrue(client.blockedSynthesis.await(2, TimeUnit.SECONDS));
+        mouth.onVoiceProcessEvent(event("queued-old", "queued old", queuedOld));
+        mouth.interruptAndClear();
+        CompletableFuture<Void> fresh = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("fresh", "fresh", fresh));
+
+        await(activeOld);
+        await(queuedOld);
+        await(fresh);
+        assertEquals(List.of("active-old"), client.cancelled);
+        assertEquals(1, output.played.size());
+        assertEquals('F' * 100, sample(output.played.getFirst(), 160));
+    }
+
+    @Test
+    void stopSettlesActiveAndQueuedHandlesAndTerminatesBothWorkers() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        client.blockRequest("active");
+        mouth.start();
+        CompletableFuture<Void> active = new CompletableFuture<>();
+        CompletableFuture<Void> queued = new CompletableFuture<>();
+        AtomicInteger activeCompletions = completionCount(active);
+        AtomicInteger queuedCompletions = completionCount(queued);
+
+        mouth.onVoiceProcessEvent(event("active", "active", active));
+        assertTrue(client.blockedSynthesis.await(2, TimeUnit.SECONDS));
+        mouth.onVoiceProcessEvent(event("queued", "queued", queued));
+        mouth.stop();
+
+        await(active);
+        await(queued);
+        assertTrue(client.cancelAllCalled.get());
+        assertTrue(output.interrupted.get());
+        assertTrue(output.closed.get());
+        assertTrue(mouth.workersStopped());
+        assertEquals(1, activeCompletions.get());
+        assertEquals(1, queuedCompletions.get());
+    }
+
+    @Test
+    void serviceCanRestartAfterACompleteStop() throws Exception {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+        mouth.stop();
+
+        mouth.start();
+        CompletableFuture<Void> completion = new CompletableFuture<>();
+        mouth.onVoiceProcessEvent(event("restart", "restart", completion));
+
+        await(completion);
+        assertFalse(mouth.workersStopped());
+    }
+
+    @Test
+    void radioRequestsRemainUnclaimedForTheDedicatedKokoroRoute() {
+        FakeClient client = new FakeClient();
+        FakeOutput output = new FakeOutput();
+        EdgeTTSImpl mouth = mouth(client, output, 0f, 100);
+        mouth.start();
+        VocalisationRequestEvent radio = new VocalisationRequestEvent(
+                "radio", null, AiVoxResponseEvent.class, true, true, "station");
+
+        mouth.onVoiceProcessEvent(radio);
+
+        assertFalse(radio.handle().isHandled());
+        assertTrue(client.requests.isEmpty());
+    }
+
+    private EdgeTTSImpl mouth(FakeClient client, FakeOutput output, float speed, int volume) {
+        return mouth(client, output, compressed -> pcm((char) compressed[0]), speed, volume);
+    }
+
+    private EdgeTTSImpl mouth(
+            FakeClient client,
+            FakeOutput output,
+            EdgeAudioDecoder decoder,
+            float speed,
+            int volume
+    ) {
+        EdgeTTSImpl mouth = new EdgeTTSImpl(
+                client,
+                decoder,
+                new EdgeVoiceProvider(),
+                output,
+                new Settings(EdgeVoices.MARY.defaultShortName(), Language.EN, speed, volume));
+        mouths.add(mouth);
+        return mouth;
+    }
+
+    private static VocalisationRequestEvent event(
+            String requestId, String text, CompletableFuture<Void> completion
+    ) {
+        return VocalisationRequestEvent.tracked(
+                requestId, text, AiVoxResponseEvent.class, true, completion);
+    }
+
+    private static byte[] pcm(char marker) {
+        byte[] pcm = new byte[400];
+        short value = (short) (marker * 100);
+        for (int i = 0; i < pcm.length; i += 2) {
+            pcm[i] = (byte) value;
+            pcm[i + 1] = (byte) (value >>> 8);
+        }
+        return pcm;
+    }
+
+    private static short sample(byte[] pcm, int index) {
+        return (short) (((pcm[index * 2 + 1] & 0xff) << 8) | (pcm[index * 2] & 0xff));
+    }
+
+    private static AtomicInteger completionCount(CompletableFuture<Void> future) {
+        AtomicInteger count = new AtomicInteger();
+        future.whenComplete((ignored, failure) -> count.incrementAndGet());
+        return count;
+    }
+
+    private static void await(CompletableFuture<Void> future) throws Exception {
+        future.get(2, TimeUnit.SECONDS);
+    }
+
+    private static Throwable awaitFailure(CompletableFuture<Void> future) throws Exception {
+        try {
+            await(future);
+            return fail("future should have completed exceptionally");
+        } catch (ExecutionException failure) {
+            return failure.getCause();
+        }
+    }
+
+    private static void awaitCondition(BooleanSupplier condition) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (!condition.getAsBoolean() && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        assertTrue(condition.getAsBoolean());
+    }
+
+    private record Settings(
+            String selectedVoiceName,
+            Language language,
+            float speechSpeed,
+            int voiceVolume
+    ) implements EdgeTtsSettings {
+    }
+
+    private static final class FakeClient implements EdgeSynthesisClient {
+        private final List<EdgeSynthesisRequest> requests = new CopyOnWriteArrayList<>();
+        private final List<String> cancelled = new CopyOnWriteArrayList<>();
+        private final CountDownLatch twoSyntheses = new CountDownLatch(2);
+        private final CountDownLatch blockedSynthesis = new CountDownLatch(1);
+        private final CountDownLatch releaseSynthesis = new CountDownLatch(1);
+        private final AtomicBoolean cancelAllCalled = new AtomicBoolean();
+        private final AtomicInteger voiceListAttempts = new AtomicInteger();
+        private volatile String blockedRequest;
+        private volatile String failText;
+        private volatile boolean failVoiceList;
+
+        @Override
+        public List<EdgeVoice> listVoices() throws IOException {
+            voiceListAttempts.incrementAndGet();
+            if (failVoiceList) {
+                throw new IOException("simulated voice-list failure");
+            }
+            return List.of(new EdgeVoice(
+                    null, EdgeVoices.MARY.defaultShortName(), "Female", "en-US",
+                    EdgeProtocolConstants.OUTPUT_FORMAT));
+        }
+
+        @Override
+        public byte[] synthesize(EdgeSynthesisRequest request) throws IOException, InterruptedException {
+            requests.add(request);
+            twoSyntheses.countDown();
+            if (request.requestId().equals(blockedRequest)) {
+                blockedSynthesis.countDown();
+                releaseSynthesis.await();
+            }
+            if (failText != null && request.text().equalsIgnoreCase(failText)) {
+                throw new IOException("simulated network failure");
+            }
+            return new byte[]{(byte) request.text().charAt(0)};
+        }
+
+        @Override
+        public void cancel(String requestId) {
+            cancelled.add(requestId);
+            releaseSynthesis.countDown();
+        }
+
+        @Override
+        public void cancelAll() {
+            cancelAllCalled.set(true);
+            releaseSynthesis.countDown();
+        }
+
+        void blockRequest(String requestId) {
+            blockedRequest = requestId;
+        }
+    }
+
+    private static final class FakeOutput implements EdgeAudioOutput {
+        private final List<byte[]> played = new CopyOnWriteArrayList<>();
+        private final CountDownLatch playStarted = new CountDownLatch(1);
+        private final CountDownLatch playbackRelease = new CountDownLatch(1);
+        private final AtomicBoolean blockPlayback = new AtomicBoolean();
+        private final AtomicBoolean interrupted = new AtomicBoolean();
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final AtomicBoolean failNext = new AtomicBoolean();
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public boolean play(byte[] pcm, BooleanSupplier interruptionRequested) throws Exception {
+            played.add(pcm.clone());
+            playStarted.countDown();
+            if (blockPlayback.get()) {
+                while (!playbackRelease.await(20, TimeUnit.MILLISECONDS)) {
+                    if (interruptionRequested.getAsBoolean()) {
+                        return false;
+                    }
+                }
+            }
+            if (failNext.compareAndSet(true, false)) {
+                throw new IOException("simulated audio device failure");
+            }
+            return !interruptionRequested.getAsBoolean();
+        }
+
+        @Override
+        public void interrupt() {
+            interrupted.set(true);
+            playbackRelease.countDown();
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+
+        void blockPlayback() {
+            blockPlayback.set(true);
+        }
+
+        void releasePlayback() {
+            playbackRelease.countDown();
+        }
+    }
+
+    private static final class SuccessRecorder {
+        private final AtomicInteger count = new AtomicInteger();
+
+        @Subscribe
+        public void onSuccess(VocalisationSuccessfulEvent<?> event) {
+            count.incrementAndGet();
+        }
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/EdgeVoiceProviderTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/EdgeVoiceProviderTest.java
@@ -1,0 +1,86 @@
+package elite.intel.ai.mouth.edge;
+
+import elite.intel.i18n.Language;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EdgeVoiceProviderTest {
+    @Test
+    void parsesVoiceMetadataAndResolvesExactDynamicVoice() throws Exception {
+        String json = """
+                [{"Name":"Full Jenny","ShortName":"en-US-JennyNeural","Gender":"Female",
+                  "Locale":"en-US","SuggestedCodec":"audio-24khz-48kbitrate-mono-mp3"}]
+                """;
+        List<EdgeVoice> voices = EdgeVoiceListParser.parse(json);
+        EdgeVoiceProvider provider = new EdgeVoiceProvider();
+        provider.setAvailableVoices(voices);
+
+        assertEquals("en-US-JennyNeural",
+                provider.resolve(EdgeVoices.JENNIFER.name(), Language.EN).shortName());
+        assertEquals("Full Jenny", voices.getFirst().protocolName());
+    }
+
+    @Test
+    void unavailableSelectionsUseDeterministicFemaleLocaleThenKnownFallback() {
+        EdgeVoiceProvider provider = new EdgeVoiceProvider();
+        provider.setAvailableVoices(List.of(
+                voice("en-US-ZoeNeural", "Female", "en-US"),
+                voice("en-US-AdamNeural", "Male", "en-US"),
+                voice("de-DE-KatjaNeural", "Female", "de-DE")));
+
+        assertEquals("en-US-ZoeNeural", provider.resolve(EdgeVoices.MARY.name(), Language.EN).shortName());
+        assertEquals("en-US-ZoeNeural", provider.resolve(EdgeVoices.JAKE.name(), Language.EN).shortName());
+        assertEquals("de-DE-KatjaNeural", provider.resolve(EdgeVoices.MARY.name(), Language.DE).shortName());
+
+        provider.clear();
+        assertEquals("ru-RU-SvetlanaNeural",
+                provider.resolve(EdgeVoices.MARY.name(), Language.RU).shortName());
+        assertEquals("ru-RU-SvetlanaNeural",
+                provider.resolve(EdgeVoices.JAKE.name(), Language.RU).shortName());
+    }
+
+    @Test
+    void malformedOrEmptyVoiceListsFailClosed() {
+        assertThrows(EdgeProtocolException.class, () -> EdgeVoiceListParser.parse("{}"));
+        assertThrows(EdgeProtocolException.class, () -> EdgeVoiceListParser.parse("[]"));
+        assertThrows(EdgeProtocolException.class,
+                () -> EdgeVoiceListParser.parse("[{\"ShortName\":\"x\"}]"));
+        assertThrows(EdgeProtocolException.class,
+                () -> EdgeVoiceListParser.parse("[{\"ShortName\":[],\"Gender\":\"Female\",\"Locale\":\"en-US\"}]"));
+
+        EdgeVoiceProvider provider = new EdgeVoiceProvider();
+        assertThrows(IllegalArgumentException.class, () -> provider.setAvailableVoices(List.of()));
+        assertFalse(provider.hasAvailableVoices());
+    }
+
+    @Test
+    void arbitraryPersistedShortNamesResolveWhenFemaleAndRejectMaleForMainVoice() {
+        EdgeVoiceProvider provider = new EdgeVoiceProvider();
+        provider.setAvailableVoices(List.of(
+                voice("en-US-AvaNeural", "Female", "en-US"),
+                voice("en-US-GuyNeural", "Male", "en-US")));
+
+        assertEquals("en-US-AvaNeural", provider.resolve("en-US-AvaNeural", Language.EN).shortName());
+        assertEquals("en-US-AvaNeural", provider.resolve("en-US-GuyNeural", Language.EN).shortName());
+    }
+
+    @Test
+    void persistedGoogleAliasesDegradeDeterministicallyAndNativeShortNamesArePreserved() {
+        assertEquals(EdgeVoices.JENNIFER.defaultShortName(),
+                EdgeVoices.femaleShortNameOrDefault("JENNIFER"));
+        assertEquals(EdgeVoices.DEFAULT_FEMALE.defaultShortName(),
+                EdgeVoices.femaleShortNameOrDefault("JAKE"));
+        assertEquals("en-US-AvaNeural", EdgeVoices.femaleShortNameOrDefault("en-US-AvaNeural"));
+        assertEquals(EdgeVoices.DEFAULT_FEMALE.defaultShortName(),
+                EdgeVoices.femaleShortNameOrDefault("not-a-voice"));
+    }
+
+    private static EdgeVoice voice(String shortName, String gender, String locale) {
+        return new EdgeVoice(null, shortName, gender, locale, EdgeProtocolConstants.OUTPUT_FORMAT);
+    }
+}

--- a/app/src/test/java/elite/intel/ai/mouth/edge/JavaSoundEdgeAudioOutputTest.java
+++ b/app/src/test/java/elite/intel/ai/mouth/edge/JavaSoundEdgeAudioOutputTest.java
@@ -1,0 +1,126 @@
+package elite.intel.ai.mouth.edge;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JavaSoundEdgeAudioOutputTest {
+    @Test
+    void opensRequiredPcmFormatAndHonoursPlaybackInterruption() throws Exception {
+        FakeLine fake = new FakeLine(false);
+        AtomicReference<AudioFormat> requestedFormat = new AtomicReference<>();
+        JavaSoundEdgeAudioOutput output = new JavaSoundEdgeAudioOutput(
+                () -> null,
+                (info, mixer) -> {
+                    requestedFormat.set((AudioFormat) info.getFormats()[0]);
+                    return fake.proxy;
+                });
+
+        output.open();
+
+        AudioFormat format = requestedFormat.get();
+        assertEquals(24_000f, format.getSampleRate());
+        assertEquals(16, format.getSampleSizeInBits());
+        assertEquals(1, format.getChannels());
+        assertTrue(format.getEncoding() == AudioFormat.Encoding.PCM_SIGNED);
+        assertFalse(format.isBigEndian());
+
+        byte[] pcm = new byte[960];
+        assertTrue(output.play(pcm, () -> false));
+        assertTrue(fake.bytesWritten >= pcm.length);
+        assertTrue(fake.calls.contains("drain"));
+
+        int writesBeforeInterrupt = fake.writeLengths.size();
+        assertFalse(output.play(pcm, () -> true));
+        assertEquals(writesBeforeInterrupt + 1, fake.writeLengths.size(),
+                "an interrupted task may write the sentence gap but no PCM");
+        assertTrue(fake.calls.contains("flush"));
+
+        output.interrupt();
+        output.close();
+        assertFalse(fake.open.get());
+        assertTrue(fake.calls.containsAll(List.of("stop", "flush", "start", "close")));
+    }
+
+    @Test
+    void closesLineWhenOpeningFails() {
+        FakeLine fake = new FakeLine(true);
+        JavaSoundEdgeAudioOutput output = new JavaSoundEdgeAudioOutput(
+                () -> null, (info, mixer) -> fake.proxy);
+
+        assertThrows(LineUnavailableException.class, output::open);
+
+        assertTrue(fake.calls.contains("close"));
+    }
+
+    private static final class FakeLine {
+        private final boolean failOnOpen;
+        private final AtomicBoolean open = new AtomicBoolean();
+        private final List<String> calls = new ArrayList<>();
+        private final List<Integer> writeLengths = new ArrayList<>();
+        private AudioFormat format;
+        private int bytesWritten;
+        private final SourceDataLine proxy;
+
+        private FakeLine(boolean failOnOpen) {
+            this.failOnOpen = failOnOpen;
+            proxy = (SourceDataLine) Proxy.newProxyInstance(
+                    SourceDataLine.class.getClassLoader(),
+                    new Class<?>[]{SourceDataLine.class},
+                    (ignored, method, args) -> invoke(method.getName(), args));
+        }
+
+        private Object invoke(String name, Object[] args) throws LineUnavailableException {
+            return switch (name) {
+                case "open" -> {
+                    open.set(true);
+                    if (args != null && args.length > 0 && args[0] instanceof AudioFormat audioFormat) {
+                        format = audioFormat;
+                    }
+                    calls.add("open");
+                    if (failOnOpen) {
+                        throw new LineUnavailableException("test open failure");
+                    }
+                    yield null;
+                }
+                case "isOpen" -> open.get();
+                case "getFormat" -> format;
+                case "write" -> {
+                    int length = (int) args[2];
+                    bytesWritten += length;
+                    writeLengths.add(length);
+                    yield length;
+                }
+                case "close" -> {
+                    open.set(false);
+                    calls.add("close");
+                    yield null;
+                }
+                case "start", "stop", "flush", "drain" -> {
+                    calls.add(name);
+                    yield null;
+                }
+                case "isRunning", "isActive", "isControlSupported" -> false;
+                case "available", "getBufferSize", "getFramePosition" -> 0;
+                case "getLongFramePosition", "getMicrosecondPosition" -> 0L;
+                case "getLevel" -> 0f;
+                case "getControls" -> new javax.sound.sampled.Control[0];
+                case "getLineInfo", "addLineListener", "removeLineListener" -> null;
+                case "toString" -> "FakeSourceDataLine";
+                default -> throw new UnsupportedOperationException(name);
+            };
+        }
+    }
+}

--- a/app/src/test/java/elite/intel/session/PerShipVoicePersonalityTest.java
+++ b/app/src/test/java/elite/intel/session/PerShipVoicePersonalityTest.java
@@ -1,6 +1,7 @@
 package elite.intel.session;
 
 import elite.intel.ai.brain.ShipPersonality;
+import elite.intel.ai.mouth.edge.EdgeVoices;
 import elite.intel.ai.mouth.google.GoogleVoices;
 import elite.intel.ai.mouth.kokoro.KokoroVoices;
 import elite.intel.db.dao.ShipDao;
@@ -82,5 +83,27 @@ class PerShipVoicePersonalityTest {
 
         assertEquals(KokoroVoices.NOVA, session.getKokoroVoice());
         assertEquals(GoogleVoices.DEFAULT_FEMALE, session.getGoogleVoice());
+        assertEquals(EdgeVoices.DEFAULT_FEMALE, session.getEdgeVoice());
+    }
+
+    @Test
+    void edgeUsesTheExistingCloudVoiceNameWithoutNewShipState() {
+        SystemSession session = SystemSession.getInstance();
+
+        saveShip(401, EdgeVoices.JENNIFER.name(), ShipPersonality.CASUAL.name());
+        makeActive(401);
+
+        assertEquals(EdgeVoices.JENNIFER, session.getEdgeVoice());
+        assertEquals(EdgeVoices.JENNIFER.defaultShortName(), session.getEdgeVoiceName());
+    }
+
+    @Test
+    void edgePreservesAnArbitraryProviderShortNameInTheExistingShipField() {
+        SystemSession session = SystemSession.getInstance();
+
+        saveShip(402, "en-US-AvaNeural", ShipPersonality.CASUAL.name());
+        makeActive(402);
+
+        assertEquals("en-US-AvaNeural", session.getEdgeVoiceName());
     }
 }

--- a/app/src/test/java/elite/intel/ui/screen/CommanderTabPanelVoiceLabelTest.java
+++ b/app/src/test/java/elite/intel/ui/screen/CommanderTabPanelVoiceLabelTest.java
@@ -1,0 +1,151 @@
+package elite.intel.ui.screen;
+
+import elite.intel.ai.mouth.edge.EdgeVoices;
+import elite.intel.ai.mouth.google.GoogleVoices;
+import elite.intel.ai.mouth.kokoro.KokoroVoices;
+import elite.intel.i18n.Language;
+import elite.intel.session.SystemSession;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Fleet Voice Configuration must show only the logical voice identity plus its friendly description
+ * (e.g. "Mary - American female"), never a TTS provider's native voice id. Edge Read Aloud went through two
+ * regressions on the way here:
+ * <ol>
+ *     <li>The fleet grid's Edge combo options and normalized selection were built from
+ *     {@link EdgeVoices#defaultShortName()} instead of the logical enum name, so
+ *     {@link CommanderTabPanel#voiceLabel} received an already-resolved ShortName and re-appended another one
+ *     on top of it (e.g. "Mary - en-US-EmmaMultilingualNeural").</li>
+ *     <li>After that was fixed, Edge showed only the bare logical name ("Mary") with no description, unlike
+ *     Google/Kokoro which both show "DisplayName - accent"/"description". {@link EdgeVoices} and
+ *     {@link GoogleVoices} enum names match one-for-one by design (same accents too), so
+ *     {@link CommanderTabPanel#edgeVoiceLabel} now reuses {@link GoogleVoices}'s descriptor instead of
+ *     duplicating "American female" / "British female" literals in {@link EdgeVoices}.</li>
+ * </ol>
+ */
+class CommanderTabPanelVoiceLabelTest {
+
+    private static void runAsEdge(Runnable body) {
+        SystemSession session = SystemSession.getInstance();
+        boolean previousLocal = session.useLocalTTS();
+        String previousKey = session.getTtsApiKey();
+        Language previousLanguage = session.getLanguage();
+        try {
+            session.setUseLocalTTS(false);
+            session.setTtsApiKey("edge://");
+            session.setLanguage(Language.EN); // the desired display text ("American female") is English-only
+            body.run();
+        } finally {
+            session.setUseLocalTTS(previousLocal);
+            session.setTtsApiKey(previousKey);
+            session.setLanguage(previousLanguage);
+        }
+    }
+
+    @Test
+    void edgeLabelIsTheFriendlyLogicalDescriptionForTheStoredEnumName() {
+        runAsEdge(() -> {
+            assertEquals("Mary - American female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.MARY.name()));
+            assertEquals("Anna - British female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.ANNA.name()));
+            assertEquals("Emma - American female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.EMMA.name()));
+            assertEquals("Jennifer - American female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.JENNIFER.name()));
+            assertEquals("Olivia - British female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.OLIVIA.name()));
+            assertEquals("Rachel - American female", CommanderTabPanel.edgeVoiceLabel(EdgeVoices.RACHEL.name()));
+        });
+    }
+
+    @Test
+    void edgeLabelIsTheFriendlyDescriptionEvenForALegacyPersistedShortName() {
+        runAsEdge(() -> {
+            // A ship saved while the ShortName-leak bug was live (or any other provider-native value) must
+            // still resolve to the same friendly logical label, not the ShortName.
+            assertEquals("Mary - American female",
+                    CommanderTabPanel.edgeVoiceLabel(EdgeVoices.MARY.defaultShortName()));
+        });
+    }
+
+    @Test
+    void edgeLabelNeverLeaksTheProviderNativeShortName() {
+        runAsEdge(() -> {
+            for (EdgeVoices voice : EdgeVoices.values()) {
+                String label = CommanderTabPanel.edgeVoiceLabel(voice.name());
+                assertFalse(label.contains(voice.defaultShortName()),
+                        "label leaked the Edge ShortName: " + label);
+                assertFalse(label.toLowerCase().contains("neural"),
+                        "label leaked Edge protocol naming: " + label);
+            }
+        });
+    }
+
+    @Test
+    void edgeAndGooglePresentTheSameFriendlyDescriptionForTheSameLogicalIdentity() {
+        // EdgeVoices and GoogleVoices enum names (and accents) match one-for-one by design; the fleet grid
+        // must read identically for both providers rather than inventing separate wording for Edge.
+        runAsEdge(() -> {
+            for (EdgeVoices voice : EdgeVoices.values()) {
+                String expected = voice.displayName() + " - " + GoogleVoices.valueOf(voice.name()).getDescription();
+                assertEquals(expected, CommanderTabPanel.edgeVoiceLabel(voice.name()),
+                        "Edge label diverged from the established Google terminology for " + voice.name());
+            }
+        });
+    }
+
+    @Test
+    void normalizeVoiceToFemaleKeepsTheLogicalNameForEdgeNotTheShortName() {
+        runAsEdge(() -> {
+            assertEquals(EdgeVoices.JENNIFER.name(),
+                    CommanderTabPanel.normalizeVoiceToFemale(EdgeVoices.JENNIFER.name()));
+            // A raw/legacy ShortName still normalizes to a logical name, keeping the stored value in the
+            // same vocabulary as the dropdown's option list (enum names, see initData()).
+            assertEquals(EdgeVoices.MARY.name(),
+                    CommanderTabPanel.normalizeVoiceToFemale(EdgeVoices.MARY.defaultShortName()));
+            // Ship voices are female-only: a legacy male voice resolves to the default female's logical name.
+            assertEquals(EdgeVoices.DEFAULT_FEMALE.name(),
+                    CommanderTabPanel.normalizeVoiceToFemale(EdgeVoices.JAKE.name()));
+        });
+    }
+
+    @Test
+    void normalizedEdgeSelectionStillResolvesToTheCorrectEdgeProviderVoice() {
+        runAsEdge(() -> {
+            String normalized = CommanderTabPanel.normalizeVoiceToFemale(EdgeVoices.JENNIFER.name());
+            // This mirrors exactly how EdgeTTSImpl.enqueue() turns a fleet-grid voice selection into the
+            // ShortName used for synthesis, proving the demo/play-preview path still reaches the right
+            // Edge voice after the logical name round-trips through the fleet grid.
+            assertEquals(EdgeVoices.JENNIFER.defaultShortName(),
+                    EdgeVoices.femaleShortNameOrDefault(normalized));
+        });
+    }
+
+    @Test
+    void googleNormalizationIsUnaffectedByTheEdgeFix() {
+        SystemSession session = SystemSession.getInstance();
+        boolean previousLocal = session.useLocalTTS();
+        String previousKey = session.getTtsApiKey();
+        try {
+            session.setUseLocalTTS(false);
+            session.setTtsApiKey(null); // no Edge key -> Google branch
+            assertEquals(GoogleVoices.femaleOrDefault(GoogleVoices.EMMA.name()).name(),
+                    CommanderTabPanel.normalizeVoiceToFemale(GoogleVoices.EMMA.name()));
+        } finally {
+            session.setUseLocalTTS(previousLocal);
+            session.setTtsApiKey(previousKey);
+        }
+    }
+
+    @Test
+    void kokoroNormalizationIsUnaffectedByTheEdgeFix() {
+        SystemSession session = SystemSession.getInstance();
+        boolean previousLocal = session.useLocalTTS();
+        try {
+            session.setUseLocalTTS(true);
+            assertEquals(KokoroVoices.femaleOrDefault(KokoroVoices.NOVA.name()).name(),
+                    CommanderTabPanel.normalizeVoiceToFemale(KokoroVoices.NOVA.name()));
+        } finally {
+            session.setUseLocalTTS(previousLocal);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #22 by adding Microsoft Edge online Read Aloud TTS as a vocalisation provider.

This uses the consumer Edge Read Aloud service rather than Azure Speech and therefore does not require a Microsoft API key or billing account.

Because the existing provider factory selects cloud TTS from the TTS-key field, the reserved selector `edge://` is used to select Edge without changing the public API, database schema, or adding new provider UI controls.

## Implementation

- Adds a native Java implementation of the Microsoft Edge Read Aloud HTTPS/WebSocket protocol.
- Adds dynamic Edge voice discovery and provider-specific voice resolution.
- Preserves EliteIntel's existing logical per-ship voice identities and maps them internally to Edge voices.
- Supports voice choice, random voices, speech speed, volume, interruption, queueing, and configured audio output.
- Preserves Kokoro ownership of radio speech.
- Uses separate synthesis and playback workers so synthesis can run ahead while maintaining ordered playback.
- Implements current TrustedClientToken, MUID, Sec-MS-GEC, framing, clock-skew retry, timeouts, and cancellation behaviour.
- Enforces Edge's escaped 4,096-byte UTF-8 synthesis limit.
- Decodes Edge's 24 kHz mono MP3 output to PCM-16 LE before `AudioDeClicker` processing and playback.
- Adds JLayer decoder packaging and third-party licence notices.
- Keeps provider-native Edge ShortNames out of Fleet Voice Configuration and retains the existing friendly logical labels such as `Mary - American female`.

## Provider selection

- `edge://` → Microsoft Edge Read Aloud
- Google TTS key → Google TTS
- local TTS enabled → Kokoro
- blank/unknown cloud selector → existing Kokoro fallback

Existing provider-selection behaviour is preserved.

## Validation

After rebasing onto current upstream `master`:

- targeted Edge/provider/UI integration tests passed
- full Gradle test suite passed
- full Gradle build passed
- `shadowJar` passed
- `git diff --check` passed
- final diff contains 51 files, 4,607 insertions and 33 deletions

Live Microsoft validation using the Java implementation also passed:

- Edge voice enumeration returned 322 voices
- two independent synthesis requests succeeded
- MP3 decoded successfully to expected 24 kHz mono PCM
- Java Sound playback succeeded

Manual end-to-end application testing passed:

- `edge://` correctly selects Edge TTS
- Edge voices synthesize and play through the normal application path
- playback is clean
- per-ship voice selection works through the existing logical voice mappings
- friendly Fleet Voice labels remain consistent with the existing UI
- speech volume and speed use the existing controls

A Google TTS playback pop noticed during testing was reproduced on the pre-Edge baseline and is unrelated to this change.

## Maintenance note

Microsoft Edge Read Aloud is an unofficial/private consumer protocol rather than a supported Microsoft API. Endpoints, client/token values, headers, or framing may change in the future. Protocol-specific code is isolated in the Edge provider package to keep future maintenance contained.

Closes #22
