### PR TITLE
Fix nearest trader and broker distance sorting

### DIFF
--- a/app/src/main/java/elite/intel/gameapi/search/spansh/station/TradersAndBrokersSearch.java
+++ b/app/src/main/java/elite/intel/gameapi/search/spansh/station/TradersAndBrokersSearch.java
@@ -11,7 +11,6 @@ import elite.intel.gameapi.search.spansh.station.traderandbroker.*;
 import elite.intel.session.PlayerSession;
 import elite.intel.util.TimeUtils;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -63,7 +62,7 @@ public class TradersAndBrokersSearch {
         coordinates.setZ(galacticCoordinates.z());
 
         criteria.setReferenceCoords(coordinates);
-        criteria.setSort(new ArrayList<>());
+        criteria.setSort(List.of(new TraderAndBrokerSearchCriteria.DistanceSort()));
 
         TraderAndBrokerSearchCriteria.Filters filters = new TraderAndBrokerSearchCriteria.Filters();
         TraderAndBrokerSearchCriteria.Distance distance = new TraderAndBrokerSearchCriteria.Distance();

--- a/app/src/main/java/elite/intel/gameapi/search/spansh/station/traderandbroker/TraderAndBrokerSearchCriteria.java
+++ b/app/src/main/java/elite/intel/gameapi/search/spansh/station/traderandbroker/TraderAndBrokerSearchCriteria.java
@@ -108,6 +108,21 @@ public class TraderAndBrokerSearchCriteria extends BaseJsonDto implements ToJson
         }
     }
 
+    /**
+     * Sorts Spansh station search results nearest-first before pagination.
+     */
+    public static class DistanceSort {
+
+        @SerializedName("distance")
+        private final Ascending distance = new Ascending();
+
+        private static class Ascending {
+
+            @SerializedName("direction")
+            private final String direction = "asc";
+        }
+    }
+
     public void setFilters(Filters filters) {
         this.filters = filters;
     }


### PR DESCRIPTION
## Summary

Fixes material trader and technology broker searches returning distant results instead of the nearest matching station.

## Cause

`TradersAndBrokersSearch` requests only the first 10 matching Spansh results:

- size = 10
- page = 0

but sends an empty sort array.

Spansh returns unsorted results in index order when no sort is specified. Elite Intel then sorts only those 10 returned results locally by distance.

This means the selected result is only the nearest of an arbitrary first page, not necessarily the nearest matching trader or broker overall.

The project already handles this correctly in `TradeStationSearchCriteria.DistanceSort`, which requests:

- distance
- ascending

before pagination.

## Fix

Adds an equivalent `DistanceSort` to `TraderAndBrokerSearchCriteria` and uses it in `TradersAndBrokersSearch`.

This causes Spansh to sort the complete matching result set by distance ascending before returning page 0.

## Testing

Tested from:

`Col 285 Sector SX-Z b14-2`

Manufactured Material Trader search before the fix selected:

- Wiradjuri
- approximately 152.71 ly away

Independent Inara validation showed several qualifying traders much closer, including systems around 28–50 ly away.

After applying the fix, the same Elite Intel command selected:

- HIP 35965
- approximately 28.21 ly away

The route was then plotted successfully.

PowerPlay filtering was left unchanged.