### PR TITLE
Fix nearest Vista and fleet carrier distance sorting

### DIFF
--- a/app/src/main/java/elite/intel/ai/brain/actions/handlers/commands/builtin/FindVistaGenomicsCommand.java
+++ b/app/src/main/java/elite/intel/ai/brain/actions/handlers/commands/builtin/FindVistaGenomicsCommand.java
@@ -65,6 +65,7 @@ public final class FindVistaGenomicsCommand implements IntelCommand {
         distance.setMax(range.intValue());
         filters.setDistance(distance);
         criteria.setFilters(filters);
+        criteria.setSort(List.of(new VistaSearchCriteria.DistanceSort()));
 
         LocationDao.Coordinates galacticCoordinates = LocationManager.getInstance().getGalacticCoordinates();
 

--- a/app/src/main/java/elite/intel/gameapi/search/spansh/findcarrier/FleetCarrierSearch.java
+++ b/app/src/main/java/elite/intel/gameapi/search/spansh/findcarrier/FleetCarrierSearch.java
@@ -6,6 +6,7 @@ import elite.intel.util.TimeUtils;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.List;
 
 public class FleetCarrierSearch {
 
@@ -22,8 +23,8 @@ public class FleetCarrierSearch {
         return instance;
     }
 
-
-    public FleetCarrierSearchResultsDto findFleetCarrier(int range, CarrierAccess carrierAccess, LocationDao.Coordinates coords) {
+    public FleetCarrierSearchResultsDto findFleetCarrier(int range, CarrierAccess carrierAccess,
+            LocationDao.Coordinates coords) {
         FleetCarrierSearchCriteriaDto criteria = new FleetCarrierSearchCriteriaDto();
         FleetCarrierSearchCriteriaDto.Filters filters = new FleetCarrierSearchCriteriaDto.Filters();
 
@@ -51,6 +52,7 @@ public class FleetCarrierSearch {
         referenceCoords.setY(coords.y());
         referenceCoords.setZ(coords.z());
         criteria.setReferenceCoords(referenceCoords);
+        criteria.setSort(List.of(new FleetCarrierSearchCriteriaDto.DistanceSort()));
 
         criteria.setSize(5);
         criteria.setPage(0);

--- a/app/src/main/java/elite/intel/gameapi/search/spansh/findcarrier/FleetCarrierSearchCriteriaDto.java
+++ b/app/src/main/java/elite/intel/gameapi/search/spansh/findcarrier/FleetCarrierSearchCriteriaDto.java
@@ -73,6 +73,21 @@ public class FleetCarrierSearchCriteriaDto implements ToJsonConvertible {
         }
     }
 
+    /**
+     * Sorts Spansh carrier search results nearest-first before pagination.
+     */
+    public static class DistanceSort {
+
+        @SerializedName("distance")
+        private final Ascending distance = new Ascending();
+
+        private static class Ascending {
+
+            @SerializedName("direction")
+            private final String direction = "asc";
+        }
+    }
+
     public static class CarrierDockingAccess {
 
         @SerializedName("value")
@@ -126,12 +141,17 @@ public class FleetCarrierSearchCriteriaDto implements ToJsonConvertible {
 
     public static class UpdatedAt {
         @SerializedName("comparison")
-        private String comparison;           // e.g. "<=>"
+        private String comparison; // e.g. "<=>"
 
         @SerializedName("value")
-        private List<String> value;          // ISO-8601 strings
+        private List<String> value; // ISO-8601 strings
 
-        public void setComparison(String comparison) { this.comparison = comparison; }
-        public void setValue(List<String> value) { this.value = value; }
+        public void setComparison(String comparison) {
+            this.comparison = comparison;
+        }
+
+        public void setValue(List<String> value) {
+            this.value = value;
+        }
     }
 }

--- a/app/src/main/java/elite/intel/gameapi/search/spansh/station/vista/VistaSearchCriteria.java
+++ b/app/src/main/java/elite/intel/gameapi/search/spansh/station/vista/VistaSearchCriteria.java
@@ -61,6 +61,21 @@ public class VistaSearchCriteria extends BaseJsonDto implements ToJsonConvertibl
         }
     }
 
+    /**
+     * Sorts Spansh station search results nearest-first before pagination.
+     */
+    public static class DistanceSort {
+
+        @SerializedName("distance")
+        private final Ascending distance = new Ascending();
+
+        private static class Ascending {
+
+            @SerializedName("direction")
+            private final String direction = "asc";
+        }
+    }
+
     public static class ReferenceCoords {
 
         @SerializedName("x")
@@ -85,8 +100,6 @@ public class VistaSearchCriteria extends BaseJsonDto implements ToJsonConvertibl
         }
     }
 
-
-
     public static class Distance {
 
         @SerializedName("min")
@@ -103,7 +116,6 @@ public class VistaSearchCriteria extends BaseJsonDto implements ToJsonConvertibl
             this.max = max;
         }
     }
-
 
     public static class Service {
 


### PR DESCRIPTION
## Summary

Fixes nearest-result sorting for Vista Genomics and Fleet Carrier searches.

Both searches were only looking at the first page of Spansh results without explicitly sorting by distance first, which could return a result much farther away than the actual nearest option.

This adds ascending distance sorting to the Spansh request before pagination.

## Tested

Starting system: `Col 285 Sector SX-Z b14-2`

Vista Genomics:
- Before: Kotandji / Michell Enterprise — 101.27 ly
- After: H Puppis / Matheson Dock — 12.19 ly
- The new result matched the nearest option shown in Inara from the same starting system

Fleet Carrier:
- Before: 83 Cancri — 198.36 ly
- After: Ramandji — 22.04 ly

`./gradlew app:build` passes successfully.

No changes were made to the existing Fleet Carrier docking access filter.