### PR TITLE
Detect every OpenAI API key format, not one fixed length

### DIFF
--- a/app/src/main/java/elite/intel/ai/KeyDetector.java
+++ b/app/src/main/java/elite/intel/ai/KeyDetector.java
@@ -41,7 +41,13 @@ public class KeyDetector {
             Map.entry(ProviderEnum.GROK, Pattern.compile("^xai-[a-zA-Z0-9_-]{40,100}$")),
             Map.entry(ProviderEnum.DEEPSEEK, Pattern.compile("^sk-[a-f0-9]{32}$")),
             Map.entry(ProviderEnum.MISTRAL, Pattern.compile("^[a-zA-Z0-9]{32}$")),
-            Map.entry(ProviderEnum.OPENAI, Pattern.compile("^sk-[a-zA-Z0-9_-]{161}$")),
+            // Every OpenAI key shape, not the one length a key happened to have when this
+            // was written: a legacy sk- key is 48 characters and a modern prefixed one has
+            // no fixed length at all, so pinning 161 rejected both. The prefixed branch and
+            // the 48-character legacy branch are each disjoint from DeepSeek's 32 hex
+            // characters, so widening this cannot make a DeepSeek key ambiguous.
+            Map.entry(ProviderEnum.OPENAI,
+                    Pattern.compile("^sk-(?:(?:proj|svcacct|admin)-[a-zA-Z0-9_-]{20,}|[a-zA-Z0-9]{48})$")),
             Map.entry(ProviderEnum.GOOGLE_STT, Pattern.compile("^AIzaSy[a-zA-Z0-9_-]{33}$")),
             Map.entry(ProviderEnum.GOOGLE_TTS, Pattern.compile("^AIzaSy[a-zA-Z0-9_-]{33}$")),
             Map.entry(ProviderEnum.GEMINI, Pattern.compile("^(AIzaSy[a-zA-Z0-9_-]{33}|AQ\\.[a-zA-Z0-9_.-]{30,150})$")),

--- a/app/src/test/java/elite/intel/ai/KeyDetectorTest.java
+++ b/app/src/test/java/elite/intel/ai/KeyDetectorTest.java
@@ -17,6 +17,38 @@ class KeyDetectorTest {
         assertEquals(ProviderEnum.UNKNOWN, KeyDetector.detectProvider("edge://", "LLM"));
     }
 
+    /**
+     * The OpenAI pattern used to demand exactly 161 characters after "sk-", which is one key's
+     * length rather than a format. A legacy key is 48 characters and a project key has no fixed
+     * length, so both fell through to UNKNOWN and companion mode refused to start.
+     */
+    @Test
+    void everyOpenAiKeyShapeIsDetected() {
+        assertEquals(ProviderEnum.OPENAI, KeyDetector.detectProvider("sk-" + "a".repeat(48), "LLM"));
+        assertEquals(ProviderEnum.OPENAI, KeyDetector.detectProvider("sk-proj-" + "aB9_-".repeat(30), "LLM"));
+        assertEquals(ProviderEnum.OPENAI, KeyDetector.detectProvider("sk-svcacct-" + "aB9_-".repeat(30), "LLM"));
+        assertEquals(ProviderEnum.OPENAI, KeyDetector.detectProvider("sk-admin-" + "aB9_-".repeat(30), "LLM"));
+    }
+
+    /**
+     * A DeepSeek key is "sk-" and 32 hex characters, which the widened OpenAI pattern must not also
+     * match - two matches resolve to UNKNOWN, which would trade one broken provider for two.
+     */
+    @Test
+    void aDeepSeekKeyStaysUnambiguous() {
+        assertEquals(ProviderEnum.DEEPSEEK, KeyDetector.detectProvider("sk-" + "0123456789abcdef".repeat(2), "LLM"));
+    }
+
+    /**
+     * A real Anthropic key must not also match the widened OpenAI pattern: two matches resolve to
+     * UNKNOWN, which is the failure this change exists to remove, arriving from the other side.
+     */
+    @Test
+    void anAnthropicKeyDoesNotMatchTheWidenedOpenAiPattern() {
+        assertEquals(ProviderEnum.ANTHROPIC,
+                KeyDetector.detectProvider("sk-ant-api03-" + "aB9_-".repeat(19), "LLM"));
+    }
+
     @Test
     void existingAndFallbackDetectionRemainUnchanged() {
         assertEquals(ProviderEnum.GOOGLE_TTS,


### PR DESCRIPTION
The OpenAI entry in `KeyDetector` is `^sk-[a-zA-Z0-9_-]{161}$`, which pins one key's length rather than describing a format. OpenAI issues several shapes and none of them has a fixed length, so almost every real key falls through to `UNKNOWN`, and `CompanionLlmGatewayFactory` then refuses to start with "Companion mode does not support the UNKNOWN provider yet". The provider is unreachable no matter how valid the key is.

I hit this with a service-account key. `sk-svcacct-` plus a 156 character tail is 167 characters, and the old pattern only ever accepted 164, so it could not have matched however cleanly it was entered.

The message is what makes this expensive to diagnose. It names the provider as unsupported, so you go looking at whether OpenAI support is finished rather than at your key. I spent a while in the wrong place before reading the regex.

## What changed

```
- ^sk-[a-zA-Z0-9_-]{161}$
+ ^sk-(?:(?:proj|svcacct|admin)-[a-zA-Z0-9_-]{20,}|[a-zA-Z0-9]{48})$
```

Two branches, one per real shape: the prefixed keys (`sk-proj-`, `sk-svcacct-`, `sk-admin-`) with a floor instead of a window, and the legacy `sk-` plus 48 character key.

## Ambiguity

Worth stating explicitly, because two matches also resolve to `UNKNOWN` and would reintroduce the same failure from the other direction. Neither branch can collide:

- DeepSeek is `sk-` plus 32 hex. The legacy branch needs exactly 48 alphanumerics, and the prefixed branch needs one of three literal prefixes.
- Anthropic is `sk-ant-`, which matches no prefix here.

Both are pinned by tests rather than left to reasoning.

## Testing

Verified against a real OpenAI service-account key, which fails the old pattern and passes the new one, and against a real Anthropic key to confirm it still resolves to `ANTHROPIC` and not to two matches. `KeyDetectorTest` covers all four OpenAI shapes plus both non-collision cases.

Anthropic and DeepSeek detection are untouched.

## Environment

Linux, on the installed build rather than from the IDE: Arch, Wayland/Hyprland, built with Temurin 21 and the packaged jar dropped into the install4j installation, then driven through the AI Services settings tab the way a commander would. The V1.1.0003 installer is what I run day to day.

Mentioning it because the Linux side is where I am useful. If you ever want something checked or reproduced there before it ships, I am happy to be the pair of eyes.
